### PR TITLE
Adds StandardJS linter to global package, in backend some back linting, and moves from requires to imports for yoga-graphql

### DIFF
--- a/apps/backend/api/controllers/PostController.js
+++ b/apps/backend/api/controllers/PostController.js
@@ -1,7 +1,7 @@
 import { includes } from 'lodash'
 import createPost from '../models/post/createPost'
 import { joinRoom, leaveRoom } from '../services/Websockets'
-const { GraphQLYogaError } = require('@graphql-yoga/node')
+import { GraphQLYogaError } from '@graphql-yoga/node'
 
 const PostController = {
   createFromEmailForm: function (req, res) {

--- a/apps/backend/api/graphql/index.js
+++ b/apps/backend/api/graphql/index.js
@@ -1,3 +1,4 @@
+import { createServer, GraphQLYogaError } from '@graphql-yoga/node'
 import { useLazyLoadedSchema } from '@envelop/core'
 import { readFileSync } from 'fs'
 import { join } from 'path'
@@ -129,7 +130,6 @@ import { makeExecutableSchema } from 'graphql-tools'
 import { inspect } from 'util'
 import { red } from 'chalk'
 import { merge, reduce } from 'lodash'
-const { createServer, GraphQLYogaError } = require('@graphql-yoga/node')
 
 const schemaText = readFileSync(join(__dirname, 'schema.graphql')).toString()
 

--- a/apps/backend/api/graphql/mutations/affiliation.js
+++ b/apps/backend/api/graphql/mutations/affiliation.js
@@ -1,4 +1,4 @@
-const { GraphQLYogaError } = require('@graphql-yoga/node')
+import { GraphQLYogaError } from '@graphql-yoga/node'
 import validator from 'validator'
 
 export async function canDeleteAffiliation (userId, affiliationId) {

--- a/apps/backend/api/graphql/mutations/collection.js
+++ b/apps/backend/api/graphql/mutations/collection.js
@@ -1,5 +1,5 @@
 import { isEmpty, mapKeys, pick, snakeCase } from 'lodash'
-const { GraphQLYogaError } = require('@graphql-yoga/node')
+import { GraphQLYogaError } from '@graphql-yoga/node'
 
 export async function addPostToCollection (userId, collectionId, postId) {
   await Collection.findValidCollectionForUser(userId, collectionId)

--- a/apps/backend/api/graphql/mutations/context_widgets.js
+++ b/apps/backend/api/graphql/mutations/context_widgets.js
@@ -1,7 +1,7 @@
-const { GraphQLYogaError } = require('@graphql-yoga/node')
+import { GraphQLYogaError } from '@graphql-yoga/node'
 import convertGraphqlData from './convertGraphqlData'
 
-export async function createContextWidget({ userId, groupId, data }) {
+export async function createContextWidget ({ userId, groupId, data }) {
   if (!userId) throw new GraphQLYogaError('No userId passed into function')
   if (!groupId) throw new GraphQLYogaError('No groupId passed into function')
   const convertedData = convertGraphqlData(data)
@@ -22,12 +22,12 @@ export async function createContextWidget({ userId, groupId, data }) {
     ...convertedData,
     group_id: groupId
   })
-  .catch(err => {
-    throw new GraphQLYogaError(`Creation of context widget failed: ${err.message}`)
-  })
+    .catch(err => {
+      throw new GraphQLYogaError(`Creation of context widget failed: ${err.message}`)
+    })
 }
 
-export async function updateContextWidget({ userId, contextWidgetId, data }) {
+export async function updateContextWidget ({ userId, contextWidgetId, data }) {
   if (!userId) throw new GraphQLYogaError('No userId passed into function')
   if (!contextWidgetId) throw new GraphQLYogaError('No context widget id passed into function')
   const convertedData = convertGraphqlData(data)
@@ -52,7 +52,7 @@ export async function updateContextWidget({ userId, contextWidgetId, data }) {
     })
 }
 
-export async function reorderContextWidget({ userId, contextWidgetId, parentId, orderInFrontOfWidgetId, addToEnd }) {
+export async function reorderContextWidget ({ userId, contextWidgetId, parentId, orderInFrontOfWidgetId, addToEnd }) {
   if (!userId) throw new GraphQLYogaError('No userId passed into function')
   if (!contextWidgetId) throw new GraphQLYogaError('No context widget id passed into function')
 
@@ -71,13 +71,12 @@ export async function reorderContextWidget({ userId, contextWidgetId, parentId, 
     orderInFrontOfWidgetId,
     addToEnd
   })
-  .catch(err => {
-    throw new GraphQLYogaError(`Reordering of context widget failed: ${err.message}`)
-  })
+    .catch(err => {
+      throw new GraphQLYogaError(`Reordering of context widget failed: ${err.message}`)
+    })
 }
 
-
-export async function removeWidgetFromMenu({ userId, contextWidgetId, groupId }) {
+export async function removeWidgetFromMenu ({ userId, contextWidgetId, groupId }) {
   if (!userId) throw new GraphQLYogaError('No userId passed into function')
   if (!contextWidgetId) throw new GraphQLYogaError('No context widget id passed into function')
 
@@ -90,13 +89,13 @@ export async function removeWidgetFromMenu({ userId, contextWidgetId, groupId })
     throw new GraphQLYogaError("You don't have permission to modify context widgets for this group")
   }
 
-  return ContextWidget.removeFromMenu({id: contextWidgetId})
+  return ContextWidget.removeFromMenu({ id: contextWidgetId })
     .catch(err => {
       throw new GraphQLYogaError(`Removing widget from menu failed: ${err.message}`)
     })
 }
 
-export async function setHomeWidget({ userId, contextWidgetId, groupId }) {
+export async function setHomeWidget ({ userId, contextWidgetId, groupId }) {
   if (!userId) throw new GraphQLYogaError('No userId passed into function')
   if (!groupId) throw new GraphQLYogaError('No groupId passed into function')
 
@@ -116,7 +115,7 @@ export async function setHomeWidget({ userId, contextWidgetId, groupId }) {
     })
 }
 
-export async function transitionGroupToNewMenu({ userId, groupId }) {
+export async function transitionGroupToNewMenu ({ userId, groupId }) {
   if (!userId) throw new GraphQLYogaError('No userId passed into function')
   if (!groupId) throw new GraphQLYogaError('No groupId passed into function')
 

--- a/apps/backend/api/graphql/mutations/event.js
+++ b/apps/backend/api/graphql/mutations/event.js
@@ -1,21 +1,19 @@
-const { GraphQLYogaError } = require('@graphql-yoga/node')
-
+import { GraphQLYogaError } from '@graphql-yoga/node'
 import { values, includes } from 'lodash/fp'
 
-export async function respondToEvent(userId, eventId, response) {
-
+export async function respondToEvent (userId, eventId, response) {
   if (!includes(response, values(EventInvitation.RESPONSE))) {
     throw new GraphQLYogaError(`response must be one of ${values(EventInvitation.RESPONSE)}. received ${response}`)
   }
 
   const event = await Post.find(eventId)
-  if(!event) {
+  if (!event) {
     throw new GraphQLYogaError('Event not found')
   }
 
-  var eventInvitation = await EventInvitation.find({userId, eventId})
+  const eventInvitation = await EventInvitation.find({ userId, eventId })
   if (eventInvitation) {
-    await eventInvitation.save({response})
+    await eventInvitation.save({ response })
   } else {
     await EventInvitation.create({
       userId,
@@ -24,24 +22,22 @@ export async function respondToEvent(userId, eventId, response) {
       response
     })
   }
-  return {success: true}
+  return { success: true }
 }
 
 export async function invitePeopleToEvent (userId, eventId, inviteeIds) {
   inviteeIds.forEach(async inviteeId => {
-    var eventInvitation = await EventInvitation.find({userId: inviteeId, eventId})
+    let eventInvitation = await EventInvitation.find({ userId: inviteeId, eventId })
     if (!eventInvitation) {
-
       await EventInvitation.create({
         userId: inviteeId,
         inviterId: userId,
         eventId
       })
-  
     }
   })
-  
-  const event = await Post.find(eventId)  
+
+  const event = await Post.find(eventId)
 
   await event.createInviteNotifications(userId, inviteeIds)
 

--- a/apps/backend/api/graphql/mutations/group.js
+++ b/apps/backend/api/graphql/mutations/group.js
@@ -1,8 +1,7 @@
+import { GraphQLYogaError } from '@graphql-yoga/node'
 import GroupService from '../../services/GroupService'
 import convertGraphqlData from './convertGraphqlData'
 import underlyingDeleteGroupTopic from '../../models/group/deleteGroupTopic'
-
-const { GraphQLYogaError } = require('@graphql-yoga/node')
 
 // Util function
 async function getStewardedGroup (userId, groupId, additionalResponsibility = '', opts = {}) {

--- a/apps/backend/api/graphql/mutations/index.js
+++ b/apps/backend/api/graphql/mutations/index.js
@@ -1,7 +1,6 @@
+import { GraphQLYogaError } from '@graphql-yoga/node'
 import { isEmpty, mapKeys, pick, snakeCase, size, trim } from 'lodash'
 import convertGraphqlData from './convertGraphqlData'
-
-const { GraphQLYogaError } = require('@graphql-yoga/node')
 
 export {
   createAffiliation,
@@ -166,8 +165,8 @@ export function updateGroupTopic (id, data) {
   const whitelist = mapKeys(pick(data, ['visibility', 'isDefault']), (v, k) => snakeCase(k))
   if (isEmpty(whitelist)) return Promise.resolve(null)
 
-  return GroupTag.query().where({id}).update(whitelist)
-  .then(() => ({success: true}))
+  return GroupTag.query().where({ id }).update(whitelist)
+    .then(() => ({ success: true }))
 }
 
 export function updateGroupTopicFollow (userId, { id, data }) {
@@ -181,27 +180,27 @@ export function updateGroupTopicFollow (userId, { id, data }) {
 
 export function markActivityRead (userId, activityid) {
   return Activity.find(activityid)
-  .then(a => {
-    if (a.get('reader_id') !== userId) return
-    return a.save({unread: false})
-  })
+    .then(a => {
+      if (a.get('reader_id') !== userId) return
+      return a.save({ unread: false })
+    })
 }
 
 export function markAllActivitiesRead (userId) {
-  return Activity.query().where('reader_id', userId).update({unread: false})
-  .then(() => ({success: true}))
+  return Activity.query().where('reader_id', userId).update({ unread: false })
+    .then(() => ({ success: true }))
 }
 
 export function unlinkAccount (userId, provider) {
   return User.find(userId)
-  .then(user => {
-    if (!user) throw new GraphQLYogaError(`Couldn't find user with id ${userId}`)
-    return user.unlinkAccount(provider)
-  })
-  .then(() => ({success: true}))
+    .then(user => {
+      if (!user) throw new GraphQLYogaError(`Couldn't find user with id ${userId}`)
+      return user.unlinkAccount(provider)
+    })
+    .then(() => ({ success: true }))
 }
 
-async function createSkill(name) {
+async function createSkill (name) {
   name = trim(name)
   if (isEmpty(name)) {
     throw new GraphQLYogaError('Skill cannot be blank')
@@ -210,7 +209,7 @@ async function createSkill(name) {
   }
   let skill
   try {
-    skill = await Skill.forge({name}).save()
+    skill = await Skill.forge({ name }).save()
   } catch (err) {
     if (!err.message || !err.message.includes('duplicate')) {
       throw err
@@ -269,26 +268,26 @@ export async function addSuggestedSkillToGroup (userId, groupId, name) {
 
 export function removeSkill (userId, skillIdOrName) {
   return Skill.find(skillIdOrName)
-  .then(skill => {
-    if (!skill) throw new GraphQLYogaError(`Couldn't find skill with ID or name ${skillIdOrName}`)
-    return skill.users().detach({ user_id: userId, type: Skill.Type.HAS })
-  })
-  .then(() => ({success: true}))
+    .then(skill => {
+      if (!skill) throw new GraphQLYogaError(`Couldn't find skill with ID or name ${skillIdOrName}`)
+      return skill.users().detach({ user_id: userId, type: Skill.Type.HAS })
+    })
+    .then(() => ({ success: true }))
 }
 
 export function removeSkillToLearn (userId, skillIdOrName) {
   return Skill.find(skillIdOrName)
-  .then(skill => {
-    if (!skill) throw new GraphQLYogaError(`Couldn't find skill with ID or name ${skillIdOrName}`)
-    return skill.usersLearning().detach({ user_id: userId, type: Skill.Type.LEARNING })
-  })
-  .then(() => ({success: true}))
+    .then(skill => {
+      if (!skill) throw new GraphQLYogaError(`Couldn't find skill with ID or name ${skillIdOrName}`)
+      return skill.usersLearning().detach({ user_id: userId, type: Skill.Type.LEARNING })
+    })
+    .then(() => ({ success: true }))
 }
 
 export async function removeSuggestedSkillFromGroup (userId, groupId, skillIdOrName) {
   const group = await Group.find(groupId)
   if (!group) throw new GraphQLYogaError('Invalid group')
-  const isAdministrator  = GroupMembership.hasResponsibility(userId, group, Responsibility.constants.RESP_ADMINISTRATION)
+  const isAdministrator = GroupMembership.hasResponsibility(userId, group, Responsibility.constants.RESP_ADMINISTRATION)
   if (!isAdministrator) throw new GraphQLYogaError('You don\'t have permission to remove skill from group')
 
   return Skill.find(skillIdOrName)
@@ -325,7 +324,7 @@ export function flagInappropriateContent (userId, { category, reason, linkData }
     object_id: linkData.id,
     object_type: linkData.type
   })
-    .tap(flaggedItem => Queue.classMethod('FlaggedItem', 'notifyModerators', {id: flaggedItem.id}))
+    .tap(flaggedItem => Queue.classMethod('FlaggedItem', 'notifyModerators', { id: flaggedItem.id }))
     .then(() => ({ success: true }))
 }
 

--- a/apps/backend/api/graphql/mutations/invitation.js
+++ b/apps/backend/api/graphql/mutations/invitation.js
@@ -1,62 +1,63 @@
-const { GraphQLYogaError } = require('@graphql-yoga/node')
+import { GraphQLYogaError } from '@graphql-yoga/node'
 import { es } from '../../../lib/i18n/es'
 import { en } from '../../../lib/i18n/en'
 import InvitationService from '../../services/InvitationService'
-const locales = {es, en}
+
+const locales = { es, en }
 
 export async function createInvitation (userId, groupId, data) {
   const group = await Group.find(groupId)
   const user = await User.find(userId)
   const locale = user.getLocale()
   return GroupMembership.hasResponsibility(userId, group, Responsibility.constants.RESP_ADD_MEMBERS)
-  .then(ok => {
-    if (!ok) throw new GraphQLYogaError("You don't have permission to create an invitation for this group")
-  })
-  .then(() => Group.find(groupId))
-  .then((group) => {
-    if (!group) throw new GraphQLYogaError('Cannot find group to send invites for')
-    return InvitationService.create({
-      sessionUserId: userId,
-      groupId,
-      emails: data.emails,
-      message: data.message,
-      moderator: data.isModerator || false,
-      subject: locales[locale].createInvitationSubject(group.get('name'))
+    .then(ok => {
+      if (!ok) throw new GraphQLYogaError("You don't have permission to create an invitation for this group")
     })
-  })
-  .then(invitations => ({invitations}))
+    .then(() => Group.find(groupId))
+    .then((group) => {
+      if (!group) throw new GraphQLYogaError('Cannot find group to send invites for')
+      return InvitationService.create({
+        sessionUserId: userId,
+        groupId,
+        emails: data.emails,
+        message: data.message,
+        moderator: data.isModerator || false,
+        subject: locales[locale].createInvitationSubject(group.get('name'))
+      })
+    })
+    .then(invitations => ({ invitations }))
 }
 
 export function expireInvitation (userId, invitationId) {
   return InvitationService.checkPermission(userId, invitationId)
-  .then(ok => {
-    if (!ok) throw new GraphQLYogaError("You don't have permission to modify this invitation")
-  })
-  .then(() => InvitationService.expire(userId, invitationId))
-  .then(() => ({success: true}))
+    .then(ok => {
+      if (!ok) throw new GraphQLYogaError("You don't have permission to modify this invitation")
+    })
+    .then(() => InvitationService.expire(userId, invitationId))
+    .then(() => ({ success: true }))
 }
 
 export function resendInvitation (userId, invitationId) {
   return InvitationService.checkPermission(userId, invitationId)
-  .then(ok => {
-    if (!ok) throw new GraphQLYogaError("You don't have permission to modify this invitation")
-  })
-  .then(() => InvitationService.resend(invitationId))
-  .then(() => ({success: true}))
+    .then(ok => {
+      if (!ok) throw new GraphQLYogaError("You don't have permission to modify this invitation")
+    })
+    .then(() => InvitationService.resend(invitationId))
+    .then(() => ({ success: true }))
 }
 
 export async function reinviteAll (userId, groupId) {
   const group = await Group.find(groupId)
   return GroupMembership.hasResponsibility(userId, group, Responsibility.constants.RESP_ADD_MEMBERS)
-  .then(ok => {
-    if (!ok) throw new GraphQLYogaError("You don't have permission to modify this invitation")
-  })
-  .then(() => InvitationService.reinviteAll({sessionUserId: userId, groupId}))
-  .then(() => ({success: true}))
+    .then(ok => {
+      if (!ok) throw new GraphQLYogaError("You don't have permission to modify this invitation")
+    })
+    .then(() => InvitationService.reinviteAll({ sessionUserId: userId, groupId }))
+    .then(() => ({ success: true }))
 }
 
 export function useInvitation (userId, invitationToken, accessCode) {
   return InvitationService.use(userId, invitationToken, accessCode)
-  .then(membership => ({membership}))
-  .catch(error => ({error: error.message}))
+    .then(membership => ({ membership }))
+    .catch(error => ({ error: error.message }))
 }

--- a/apps/backend/api/graphql/mutations/join_request.js
+++ b/apps/backend/api/graphql/mutations/join_request.js
@@ -1,4 +1,4 @@
-const { GraphQLYogaError } = require('@graphql-yoga/node')
+import { GraphQLYogaError } from '@graphql-yoga/node'
 
 export async function createJoinRequest (userId, groupId, questionAnswers = []) {
   if (groupId && userId) {

--- a/apps/backend/api/graphql/mutations/membership.js
+++ b/apps/backend/api/graphql/mutations/membership.js
@@ -1,5 +1,5 @@
+import { GraphQLYogaError } from '@graphql-yoga/node'
 import { isEmpty, mapKeys, pick, snakeCase } from 'lodash'
-const { GraphQLYogaError } = require('@graphql-yoga/node')
 
 export async function updateMembership (userId, { groupId, data, data: { settings } }) {
   const whitelist = mapKeys(pick(data, [

--- a/apps/backend/api/graphql/mutations/moderation_actions.js
+++ b/apps/backend/api/graphql/mutations/moderation_actions.js
@@ -1,4 +1,4 @@
-const { GraphQLYogaError } = require('@graphql-yoga/node')
+import { GraphQLYogaError } from '@graphql-yoga/node'
 
 export async function createModerationAction ({ userId, data }) {
   const { groupId, text, anonymous, agreements, platformAgreements, postId } = data

--- a/apps/backend/api/graphql/mutations/post.js
+++ b/apps/backend/api/graphql/mutations/post.js
@@ -1,7 +1,7 @@
+import { GraphQLYogaError } from '@graphql-yoga/node'
 import validatePostData from '../../models/post/validatePostData'
 import underlyingCreatePost from '../../models/post/createPost'
 import underlyingUpdatePost from '../../models/post/updatePost'
-const { GraphQLYogaError } = require('@graphql-yoga/node')
 
 export function createPost (userId, data) {
   return convertGraphqlPostData(data)

--- a/apps/backend/api/graphql/mutations/responsibilities.js
+++ b/apps/backend/api/graphql/mutations/responsibilities.js
@@ -1,4 +1,4 @@
-const { GraphQLYogaError } = require('@graphql-yoga/node')
+import { GraphQLYogaError } from '@graphql-yoga/node'
 
 export async function addGroupResponsibility ({ groupId, title, description, userId }) {
   if (!userId) throw new GraphQLYogaError('No userId passed into function')

--- a/apps/backend/api/graphql/mutations/role.js
+++ b/apps/backend/api/graphql/mutations/role.js
@@ -1,4 +1,4 @@
-const { GraphQLYogaError } = require('@graphql-yoga/node')
+import { GraphQLYogaError } from '@graphql-yoga/node'
 
 export async function addGroupRole ({ groupId, color, name, description, emoji, userId }) {
   if (!userId) throw new GraphQLYogaError('No userId passed into function')
@@ -6,7 +6,7 @@ export async function addGroupRole ({ groupId, color, name, description, emoji, 
   if (groupId && name && emoji) {
     const responsibilities = await Responsibility.fetchForUserAndGroupAsStrings(userId, groupId)
 
-    if ( responsibilities.includes(Responsibility.constants.RESP_ADMINISTRATION)) {
+    if (responsibilities.includes(Responsibility.constants.RESP_ADMINISTRATION)) {
       return GroupRole.forge({ group_id: groupId, name, description, emoji, active: true, color }).save().then((savedGroupRole) => savedGroupRole)
     } else {
       throw new GraphQLYogaError('User doesn\'t have required privileges to create group role')
@@ -23,7 +23,7 @@ export async function updateGroupRole ({ groupRoleId, color, name, description, 
     const responsibilities = await Responsibility.fetchForUserAndGroupAsStrings(userId, groupId)
     if (responsibilities.includes(Responsibility.constants.RESP_ADMINISTRATION)) {
       return bookshelf.transaction(async transacting => {
-        const groupRole = await GroupRole.where({ id: groupRoleId}).fetch()
+        const groupRole = await GroupRole.where({ id: groupRoleId }).fetch()
         const verifiedActiveParam = (active == null) ? groupRole.get('active') : active
         const updatedAttributes = {
           color: color || groupRole.get('color'),
@@ -41,7 +41,6 @@ export async function updateGroupRole ({ groupRoleId, color, name, description, 
   } else {
     throw new GraphQLYogaError(`Invalid/undefined parameters to update group role: received ${JSON.stringify({ groupId, name, emoji, groupRoleId, active })}`)
   }
-
 }
 
 export async function addRoleToMember ({ userId, roleId, personId, groupId, isCommonRole }) {
@@ -69,10 +68,10 @@ export async function removeRoleFromMember ({ userId, roleId, personId, groupId,
     if (responsibilities.includes(Responsibility.constants.RESP_ADMINISTRATION) || userId === personId) {
       const useThisModel = isCommonRole
         ? MemberCommonRole.query(q => {
-            return q.where('user_id', personId)
-              .andWhere('common_role_id', roleId)
-              .andWhere('group_id', groupId)
-          })
+          return q.where('user_id', personId)
+            .andWhere('common_role_id', roleId)
+            .andWhere('group_id', groupId)
+        })
         : MemberGroupRole.query(q => {
           return q.where('user_id', personId)
             .andWhere('group_role_id', roleId)
@@ -87,5 +86,4 @@ export async function removeRoleFromMember ({ userId, roleId, personId, groupId,
   } else {
     throw new GraphQLYogaError(`Invalid/undefined parameters to remove role from member: received ${JSON.stringify({ personId, roleId, groupId })}`)
   }
-
 }

--- a/apps/backend/api/graphql/mutations/topic.js
+++ b/apps/backend/api/graphql/mutations/topic.js
@@ -1,4 +1,4 @@
-const { GraphQLYogaError } = require('@graphql-yoga/node')
+import { GraphQLYogaError } from '@graphql-yoga/node'
 
 export async function topicMutationPermissionCheck (userId, groupId) {
   const group = await Group.find(groupId)

--- a/apps/backend/api/graphql/mutations/user.js
+++ b/apps/backend/api/graphql/mutations/user.js
@@ -1,5 +1,4 @@
-const { GraphQLYogaError } = require('@graphql-yoga/node')
-
+import { GraphQLYogaError } from '@graphql-yoga/node'
 import request from 'request'
 import { decodeHyloJWT } from '../../../lib/HyloJWT'
 
@@ -99,9 +98,9 @@ export const login = (fetchOne, { req }) => async (_, { email, password }) => {
     const user = await User.authenticate(email, password)
 
     await UserSession.login(req, user, 'password')
-    
+
     return { me: fetchOne('Me', user.id) }
-  } catch(error) {
+  } catch (error) {
     return { error: error.message }
   }
 }
@@ -117,7 +116,7 @@ export const logout = ({ req }) => async () => {
 export const sendPasswordReset = async (_, { email }) => {
   try {
     const user = await User.query(q => q.whereRaw('lower(email) = ?', email.toLowerCase())).fetch()
-    
+
     if (user) {
       const nextUrl = Frontend.Route.evo.passwordSetting()
       const token = user.generateJWT()
@@ -180,7 +179,7 @@ export async function unblockUser (userId, blockedUserId) {
 
 export async function updateStripeAccount (userId, accountId) {
   // TODO: add validation on accountId
-  const user = await User.find(userId, {withRelated: 'stripeAccount'})
+  const user = await User.find(userId, { withRelated: 'stripeAccount' })
 
   await user.updateStripeAccount(accountId)
 
@@ -188,7 +187,7 @@ export async function updateStripeAccount (userId, accountId) {
 }
 
 export async function registerStripeAccount (userId, authorizationCode) {
-  const user = await User.find(userId, {withRelated: 'stripeAccount'})
+  const user = await User.find(userId, { withRelated: 'stripeAccount' })
   const options = {
     uri: 'https://connect.stripe.com/oauth/token',
     form: {
@@ -198,15 +197,15 @@ export async function registerStripeAccount (userId, authorizationCode) {
     },
     json: true
   }
-  
+
   // TODO: this should be in a promise chain
-  request.post(options, async (err, response, body) => {
+  request.post(options, async (_err, response, body) => {
     const accountId = body.stripe_user_id
     const refreshToken = body.refresh_token
     if (accountId && refreshToken) {
       await user.updateStripeAccount(accountId, refreshToken)
     }
   })
-  
+
   return { success: true }
 }

--- a/apps/backend/api/models/BlockedUser.js
+++ b/apps/backend/api/models/BlockedUser.js
@@ -1,4 +1,4 @@
-const { GraphQLYogaError } = require('@graphql-yoga/node')
+import { GraphQLYogaError } from '@graphql-yoga/node'
 
 /* eslint-disable camelcase */
 module.exports = bookshelf.Model.extend({
@@ -30,22 +30,21 @@ module.exports = bookshelf.Model.extend({
     }
 
     return this.find(userId, blockedUserId)
-    .then(existing => {
-      if (existing) return existing
+      .then(existing => {
+        if (existing) return existing
 
-      return new BlockedUser({
-        user_id: userId,
-        blocked_user_id: blockedUserId,
-        created_at: new Date(),
-        updated_at: new Date()
+        return new BlockedUser({
+          user_id: userId,
+          blocked_user_id: blockedUserId,
+          created_at: new Date(),
+          updated_at: new Date()
+        }).save()
       })
-      .save()
-    })
   },
 
   find: function (user_id, blocked_user_id) {
     if (!user_id) throw new GraphQLYogaError('Parameter user_id must be supplied.')
-    return BlockedUser.where({user_id, blocked_user_id}).fetch()
+    return BlockedUser.where({ user_id, blocked_user_id }).fetch()
   },
 
   blockedFor: function (userId) {

--- a/apps/backend/api/models/Collection.js
+++ b/apps/backend/api/models/Collection.js
@@ -1,4 +1,4 @@
-const { GraphQLYogaError } = require('@graphql-yoga/node')
+import { GraphQLYogaError } from '@graphql-yoga/node'
 
 module.exports = bookshelf.Model.extend({
   tableName: 'collections',

--- a/apps/backend/api/models/EventInvitation.js
+++ b/apps/backend/api/models/EventInvitation.js
@@ -1,4 +1,4 @@
-const { GraphQLYogaError } = require('@graphql-yoga/node')
+import { GraphQLYogaError } from '@graphql-yoga/node'
 
 /* eslint-disable camelcase */
 module.exports = bookshelf.Model.extend({
@@ -26,7 +26,7 @@ module.exports = bookshelf.Model.extend({
     INTERESTED: 'interested'
   },
 
-  create: function ({userId, inviterId, eventId, response}, trxOpts) {
+  create: function ({ userId, inviterId, eventId, response }, trxOpts) {
     if (!userId) {
       throw new GraphQLYogaError('must provide a user_id')
     }
@@ -35,20 +35,20 @@ module.exports = bookshelf.Model.extend({
       throw new GraphQLYogaError('must provide an event_id')
     }
 
-    return this.find({userId, inviterId, eventId}, trxOpts)
-    .then(existing => {
-      if (existing) return existing
+    return this.find({ userId, inviterId, eventId }, trxOpts)
+      .then(existing => {
+        if (existing) return existing
 
-      return new EventInvitation({
-        user_id: userId,
-        inviter_id: inviterId,
-        event_id: eventId,
-        response,
-        created_at: new Date(),
-        updated_at: new Date()
+        return new EventInvitation({
+          user_id: userId,
+          inviter_id: inviterId,
+          event_id: eventId,
+          response,
+          created_at: new Date(),
+          updated_at: new Date()
+        })
+          .save(null, trxOpts)
       })
-      .save(null, trxOpts)
-    })
   },
 
   find: function ({ userId, inviterId, eventId }, opts) {

--- a/apps/backend/api/models/FlaggedItem.js
+++ b/apps/backend/api/models/FlaggedItem.js
@@ -1,5 +1,4 @@
-const { GraphQLYogaError } = require('@graphql-yoga/node')
-
+import { GraphQLYogaError } from '@graphql-yoga/node'
 import { values, isEmpty, trim } from 'lodash'
 import { Validators } from '@hylo/shared'
 import { notifyModeratorsPost, notifyModeratorsMember, notifyModeratorsComment } from './flaggedItem/notifyUtils'
@@ -16,9 +15,9 @@ module.exports = bookshelf.Model.extend({
     if (!this.get('object_id')) throw new GraphQLYogaError('No object_id defined for Flagged Item')
     switch (this.get('object_type')) {
       case FlaggedItem.Type.POST:
-        return Post.find(this.get('object_id'), {withRelated: 'groups'})
+        return Post.find(this.get('object_id'), { withRelated: 'groups' })
       case FlaggedItem.Type.COMMENT:
-        return Comment.find(this.get('object_id'), {withRelated: 'post.groups'})
+        return Comment.find(this.get('object_id'), { withRelated: 'post.groups' })
       case FlaggedItem.Type.MEMBER:
         return User.find(this.get('object_id'))
       default:
@@ -27,7 +26,7 @@ module.exports = bookshelf.Model.extend({
   },
 
   async getMessageText (group) {
-    const isPublic = !group ? true : false
+    const isPublic = !group
     const link = await this.getContentLink(group, isPublic)
 
     return `${this.relations.user.get('name')} flagged a ${this.get('object_type')} in ${group ? group.get('name') : 'Public'} for being ${this.get('category')}\n` +
@@ -67,8 +66,8 @@ module.exports = bookshelf.Model.extend({
   },
 
   find (id, opts = {}) {
-    return FlaggedItem.where({id})
-    .fetch(opts)
+    return FlaggedItem.where({ id })
+      .fetch(opts)
   },
 
   create: function (attrs) {
@@ -97,7 +96,7 @@ module.exports = bookshelf.Model.extend({
   },
 
   async notifyModerators ({ id }) {
-    const flaggedItem = await FlaggedItem.find(id, {withRelated: 'user'})
+    const flaggedItem = await FlaggedItem.find(id, { withRelated: 'user' })
     switch (flaggedItem.get('object_type')) {
       case FlaggedItem.Type.POST:
         return notifyModeratorsPost(flaggedItem)

--- a/apps/backend/api/models/Group.js
+++ b/apps/backend/api/models/Group.js
@@ -1,4 +1,5 @@
 import knexPostgis from 'knex-postgis'
+import { GraphQLYogaError } from '@graphql-yoga/node'
 import { clone, defaults, difference, flatten, intersection, isEmpty, mapValues, merge, sortBy, pick, omit, omitBy, isUndefined, trim, xor } from 'lodash'
 import mbxGeocoder from '@mapbox/mapbox-sdk/services/geocoding'
 import fetch from 'node-fetch'
@@ -15,8 +16,6 @@ import { findOrCreateLocation } from '../graphql/mutations/location'
 import { whereId } from './group/queryUtils'
 import { es } from '../../lib/i18n/es'
 import { en } from '../../lib/i18n/en'
-
-const { GraphQLYogaError } = require('@graphql-yoga/node')
 
 const locales = { es, en }
 

--- a/apps/backend/api/models/GroupRelationshipInvite.js
+++ b/apps/backend/api/models/GroupRelationshipInvite.js
@@ -1,4 +1,4 @@
-const { GraphQLYogaError } = require('@graphql-yoga/node')
+import { GraphQLYogaError } from '@graphql-yoga/node'
 import EnsureLoad from './mixins/EnsureLoad'
 
 module.exports = bookshelf.Model.extend(Object.assign({
@@ -200,9 +200,9 @@ module.exports = bookshelf.Model.extend(Object.assign({
       q.whereNull('used_by_id')
       q.whereNull('expired_by_id')
     })
-    .fetchAll({withRelated: ['creator', 'group', 'tag']})
-    .tap(invitations => Promise.map(invitations.models, i => i.send()))
-    .then(invitations => invitations.pluck('id'))
+      .fetchAll({ withRelated: ['creator', 'group', 'tag'] })
+      .tap(invitations => Promise.map(invitations.models, i => i.send()))
+      .then(invitations => invitations.pluck('id'))
   }
 
 })

--- a/apps/backend/api/models/JoinRequest.js
+++ b/apps/backend/api/models/JoinRequest.js
@@ -1,4 +1,4 @@
-const { GraphQLYogaError } = require('@graphql-yoga/node')
+import { GraphQLYogaError } from '@graphql-yoga/node'
 
 module.exports = bookshelf.Model.extend({
   tableName: 'join_requests',
@@ -36,7 +36,7 @@ module.exports = bookshelf.Model.extend({
       })
       return this
     }
-    throw new GraphQLYogaError("Invalid join request")
+    throw new GraphQLYogaError('Invalid join request')
   }
 }, {
 
@@ -52,12 +52,12 @@ module.exports = bookshelf.Model.extend({
       group_id: opts.groupId,
       user_id: opts.userId,
       created_at: new Date(),
-      status: this.STATUS.Pending,
+      status: this.STATUS.Pending
     }).save()
-    .then(async request => {
-      JoinRequest.afterCreate(request)
-      return request
-    })
+      .then(async request => {
+        JoinRequest.afterCreate(request)
+        return request
+      })
   },
 
   afterCreate: async function (request) {
@@ -78,6 +78,6 @@ module.exports = bookshelf.Model.extend({
 
   find: async function (id) {
     if (!id) return Promise.resolve(null)
-    return JoinRequest.where({id}).fetch()
+    return JoinRequest.where({ id }).fetch()
   }
 })

--- a/apps/backend/api/models/LinkedAccount.js
+++ b/apps/backend/api/models/LinkedAccount.js
@@ -1,8 +1,9 @@
-const { GraphQLYogaError } = require('@graphql-yoga/node')
+import { GraphQLYogaError } from '@graphql-yoga/node'
 import bcrypt from 'bcrypt'
 import Promise from 'bluebird'
 import { get, isEmpty } from 'lodash'
 import { Validators } from '@hylo/shared'
+
 const hash = Promise.promisify(bcrypt.hash, bcrypt)
 
 module.exports = bookshelf.Model.extend({
@@ -14,17 +15,17 @@ module.exports = bookshelf.Model.extend({
   },
 
   activeUser: function () {
-    return this.belongsTo(User).query({where: {'users.active': true}})
+    return this.belongsTo(User).query({ where: { 'users.active': true } })
   },
 
   updatePassword: function (password, sessionId, { transacting } = {}) {
     return hash(password, 10)
-    .then(provider_user_id =>
-      this.save({provider_user_id}, {patch: true, transacting})
-    ).then(() => {
+      .then(provider_user_id =>
+        this.save({ provider_user_id }, { patch: true, transacting })
+      ).then(() => {
       // Log out of all other sessions for this user
-      Queue.classMethod('User', 'clearSessionsFor', { userId: this.get('user_id'), sessionId })
-    })
+        Queue.classMethod('User', 'clearSessionsFor', { userId: this.get('user_id'), sessionId })
+      })
   }
 
 }, {
@@ -38,13 +39,13 @@ module.exports = bookshelf.Model.extend({
       type === 'password'
         ? hash(password, 10)
         : Promise.resolve(null))()
-    .then(hashed => new LinkedAccount({
-      provider_key: type,
-      provider_user_id: hashed || token || profile.id,
-      user_id: userId
-    }).save({}, {transacting}))
-    .tap(() => updateUser &&
-      this.updateUser(userId, {type, profile, transacting}))
+      .then(hashed => new LinkedAccount({
+        provider_key: type,
+        provider_user_id: hashed || token || profile.id,
+        user_id: userId
+      }).save({}, { transacting }))
+      .tap(() => updateUser &&
+      this.updateUser(userId, { type, profile, transacting }))
   },
 
   tokenForUser: function (userId) {
@@ -56,21 +57,21 @@ module.exports = bookshelf.Model.extend({
 
   updateUser: function (userId, { type, profile, transacting } = {}) {
     return User.find(userId, { transacting }, false)
-    .then(user => {
-      var avatarUrl = user.get('avatar_url')
-      var attributes = this.socialMediaAttributes(type, profile)
-      if (avatarUrl && !avatarUrl.match(/gravatar/)) {
-        attributes.avatar_url = avatarUrl
-      }
-      if (!isEmpty(attributes)) {
-        const q = User.query().where('id', userId)
-        if (transacting) {
-          q.transacting(transacting)
+      .then(user => {
+        let avatarUrl = user.get('avatar_url')
+        let attributes = this.socialMediaAttributes(type, profile)
+        if (avatarUrl && !avatarUrl.match(/gravatar/)) {
+          attributes.avatar_url = avatarUrl
         }
-        return q.update(attributes)
-      }
-      return false
-    })
+        if (!isEmpty(attributes)) {
+          const q = User.query().where('id', userId)
+          if (transacting) {
+            q.transacting(transacting)
+          }
+          return q.update(attributes)
+        }
+        return false
+      })
   },
 
   socialMediaAttributes: function (type, profile) {

--- a/apps/backend/api/models/User.js
+++ b/apps/backend/api/models/User.js
@@ -5,12 +5,12 @@ import { has, isEmpty, merge, omit, pick, intersectionBy } from 'lodash'
 import fetch from 'node-fetch'
 import { v4 as uuidv4 } from 'uuid'
 import validator from 'validator'
+import { GraphQLYogaError } from '@graphql-yoga/node'
 import { Validators } from '@hylo/shared'
 import HasSettings from './mixins/HasSettings'
 import { findThread } from './post/findOrCreateThread'
 import { generateHyloJWT } from '../../lib/HyloJWT'
 import MemberCommonRole from './MemberCommonRole'
-const { GraphQLYogaError } = require('@graphql-yoga/node')
 
 module.exports = bookshelf.Model.extend(merge({
   tableName: 'users',
@@ -644,7 +644,7 @@ module.exports = bookshelf.Model.extend(merge({
   }),
 
   clearSessionsFor: async function ({ userId, sessionId }) {
-    const redisClient = await RedisClient.create()
+    const redisClient = RedisClient.create()
     for await (const key of redisClient.scanIterator({ MATCH: `sess:${userId}:*` })) {
       if (key !== 'sess:' + sessionId) {
         await redisClient.del(key)

--- a/apps/backend/api/models/UserConnection.js
+++ b/apps/backend/api/models/UserConnection.js
@@ -1,4 +1,4 @@
-const { GraphQLYogaError } = require('@graphql-yoga/node')
+import { GraphQLYogaError } from '@graphql-yoga/node'
 
 /* eslint-disable camelcase */
 module.exports = bookshelf.Model.extend({
@@ -32,16 +32,16 @@ module.exports = bookshelf.Model.extend({
       created_at: new Date(),
       updated_at: new Date()
     })
-    .save(null, { returning: '*' })
+      .save(null, { returning: '*' })
   },
 
   createOrUpdate: function (userId, otherUserId, type) {
     return this.find(userId, otherUserId, type)
       .then(connection => {
-        if (connection) return connection.save(
+        if (connection) {return connection.save(
           { updated_at: new Date() },
           { returning: '*' }
-        )
+        )}
         return this.create(userId, otherUserId, type)
       })
   },

--- a/apps/backend/api/models/comment/updateComment.js
+++ b/apps/backend/api/models/comment/updateComment.js
@@ -1,4 +1,4 @@
-const { GraphQLYogaError } = require('@graphql-yoga/node')
+import { GraphQLYogaError } from '@graphql-yoga/node'
 import { difference, uniq, isEqual } from 'lodash'
 import { updateMedia } from './util'
 

--- a/apps/backend/api/models/post/createPost.js
+++ b/apps/backend/api/models/post/createPost.js
@@ -1,8 +1,8 @@
+import { GraphQLYogaError } from '@graphql-yoga/node'
 import { flatten, merge, pick, uniq } from 'lodash'
 import setupPostAttrs from './setupPostAttrs'
 import updateChildren from './updateChildren'
 import { groupRoom, pushToSockets } from '../../services/Websockets'
-const { GraphQLYogaError } = require('@graphql-yoga/node')
 
 export default async function createPost (userId, params) {
   return setupPostAttrs(userId, merge(Post.newPostAttrs(), params), true)

--- a/apps/backend/api/models/post/findOrCreateThread.js
+++ b/apps/backend/api/models/post/findOrCreateThread.js
@@ -1,7 +1,7 @@
+import { GraphQLYogaError } from '@graphql-yoga/node'
 import { pick } from 'lodash'
 import { uniq } from 'lodash/fp'
 import { personFilter } from '../../graphql/filters'
-const { GraphQLYogaError } = require('@graphql-yoga/node')
 
 export function findThread (userIds) {
   return Post.havingExactFollowers(userIds)

--- a/apps/backend/api/models/post/updatePost.js
+++ b/apps/backend/api/models/post/updatePost.js
@@ -1,3 +1,4 @@
+import { GraphQLYogaError } from '@graphql-yoga/node'
 import setupPostAttrs from './setupPostAttrs'
 import updateChildren from './updateChildren'
 import { isEqual } from 'lodash'
@@ -6,7 +7,6 @@ import {
   updateAllMedia,
   updateFollowers
 } from './util'
-const { GraphQLYogaError } = require('@graphql-yoga/node')
 
 export default function updatePost (userId, id, params) {
   if (!id) throw new GraphQLYogaError('updatePost called with no ID')

--- a/apps/backend/api/models/post/validatePostData.js
+++ b/apps/backend/api/models/post/validatePostData.js
@@ -1,4 +1,4 @@
-const { GraphQLYogaError } = require('@graphql-yoga/node')
+import { GraphQLYogaError } from '@graphql-yoga/node'
 import { includes, isEmpty, trim } from 'lodash'
 
 export default function validatePostData (userId, data) {

--- a/apps/backend/api/policies/checkAndDecodeToken.js
+++ b/apps/backend/api/policies/checkAndDecodeToken.js
@@ -1,4 +1,4 @@
-const { GraphQLYogaError } = require('@graphql-yoga/node')
+import { GraphQLYogaError } from '@graphql-yoga/node'
 
 module.exports = function checkAndDecodeToken (req, res, next) {
   const token = req.param('token')

--- a/apps/backend/api/services/InvitationService.js
+++ b/apps/backend/api/services/InvitationService.js
@@ -1,4 +1,4 @@
-const { GraphQLYogaError } = require('@graphql-yoga/node')
+import { GraphQLYogaError } from '@graphql-yoga/node'
 import validator from 'validator'
 import { TextHelpers } from '@hylo/shared'
 import { get, isEmpty, map, merge } from 'lodash/fp'

--- a/apps/backend/api/services/Search/forUsers.js
+++ b/apps/backend/api/services/Search/forUsers.js
@@ -1,6 +1,6 @@
+import { GraphQLYogaError } from '@graphql-yoga/node'
 import { countTotal } from '../../../lib/util/knex'
 import { filterAndSortUsers } from './util'
-const { GraphQLYogaError } = require('@graphql-yoga/node')
 
 export default function (opts) {
   const { groups } = opts

--- a/apps/backend/lib/graphql-bookshelf-bridge/util/applyPagination.js
+++ b/apps/backend/lib/graphql-bookshelf-bridge/util/applyPagination.js
@@ -1,4 +1,4 @@
-const { GraphQLYogaError } = require('@graphql-yoga/node')
+import { GraphQLYogaError } from '@graphql-yoga/node'
 import { countTotal } from '../../../lib/util/knex'
 import { snakeCase } from 'lodash'
 

--- a/apps/backend/lib/uploader/validation.js
+++ b/apps/backend/lib/uploader/validation.js
@@ -1,4 +1,4 @@
-const { GraphQLYogaError } = require('@graphql-yoga/node')
+import { GraphQLYogaError } from '@graphql-yoga/node'
 import { values } from 'lodash'
 import * as types from './types'
 

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -55,8 +55,7 @@
     "nock": "^13.5.5",
     "nodemon": "^1.12.1",
     "nyc": "^10.0",
-    "socket.io-client": "^2.3.1",
-    "standard": "16.0.4"
+    "socket.io-client": "^2.3.1"
   },
   "dependencies": {
     "@airbnb/node-memwatch": "^2.0.0",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -156,7 +156,6 @@
     "react-test-renderer": "18.3.1",
     "redux-logger": "^3.0.6",
     "reselect-tools": "^0.0.7",
-    "standard": "^17.1.2",
     "tailwind-merge": "^2.5.4",
     "timezone-mock": "^1.3.6",
     "typescript": "5.0.4",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -277,7 +277,6 @@
     "postcss-safe-parser": "^7.0.0",
     "postcss-scss": "^4.0.9",
     "prettier": "^2.1.2",
-    "standard": "17.1.2",
     "tailwind-merge": "^2.5.4",
     "tailwindcss": "^3.4.14",
     "tailwindcss-animate": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@hylo/shared": "workspace:*"
   },
   "devDependencies": {
+    "standard": "^17.1.2",
     "typescript": "5.0.4"
   },
   "resolutions": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -55,7 +55,6 @@
     "concurrently": "^7.0.0",
     "eslint": "^8.8.0",
     "jest": "^27.5.0",
-    "standard": "^16.0.4",
     "typescript": "5.0.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3156,24 +3156,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/eslintrc@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "@eslint/eslintrc@npm:0.3.0"
-  dependencies:
-    ajv: "npm:^6.12.4"
-    debug: "npm:^4.1.1"
-    espree: "npm:^7.3.0"
-    globals: "npm:^12.1.0"
-    ignore: "npm:^4.0.6"
-    import-fresh: "npm:^3.2.1"
-    js-yaml: "npm:^3.13.1"
-    lodash: "npm:^4.17.20"
-    minimatch: "npm:^3.0.4"
-    strip-json-comments: "npm:^3.1.1"
-  checksum: 10/4116db7caeceadaf1e9d0377607e79e7ec94bfe09f7453eed8d8f4a7bd3d6fb605bb6b1f9e615ed5cbc9ac84633161d8fec2655e501069dc1085729c45b54c02
-  languageName: node
-  linkType: hard
-
 "@eslint/eslintrc@npm:^1.3.0":
   version: 1.4.1
   resolution: "@eslint/eslintrc@npm:1.4.1"
@@ -3701,7 +3683,6 @@ __metadata:
     luxon: "npm:^3.5.0"
     marked: "npm:^4.2.1"
     pretty-date: "npm:^0.2.0"
-    standard: "npm:^16.0.4"
     trunc-html: "npm:^1.1.2"
     trunc-text: "npm:^1.0.2"
     typescript: "npm:5.0.4"
@@ -9948,7 +9929,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-jsx@npm:^5.3.1, acorn-jsx@npm:^5.3.2":
+"acorn-jsx@npm:^5.3.2":
   version: 5.3.2
   resolution: "acorn-jsx@npm:5.3.2"
   peerDependencies:
@@ -10018,7 +9999,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^7.1.1, acorn@npm:^7.4.0":
+"acorn@npm:^7.1.1":
   version: 7.4.1
   resolution: "acorn@npm:7.4.1"
   bin:
@@ -10085,18 +10066,6 @@ __metadata:
     json-schema-traverse: "npm:^0.4.1"
     uri-js: "npm:^4.2.2"
   checksum: 10/48d6ad21138d12eb4d16d878d630079a2bda25a04e745c07846a4ad768319533031e28872a9b3c5790fa1ec41aabdf2abed30a56e5a03ebc2cf92184b8ee306c
-  languageName: node
-  linkType: hard
-
-"ajv@npm:^8.0.1":
-  version: 8.17.1
-  resolution: "ajv@npm:8.17.1"
-  dependencies:
-    fast-deep-equal: "npm:^3.1.3"
-    fast-uri: "npm:^3.0.1"
-    json-schema-traverse: "npm:^1.0.0"
-    require-from-string: "npm:^2.0.2"
-  checksum: 10/ee3c62162c953e91986c838f004132b6a253d700f1e51253b99791e2dbfdb39161bc950ebdc2f156f8568035bb5ed8be7bd78289cd9ecbf3381fe8f5b82e3f33
   languageName: node
   linkType: hard
 
@@ -10174,13 +10143,6 @@ __metadata:
   version: 4.1.1
   resolution: "ansi-colors@npm:4.1.1"
   checksum: 10/e862fddd0a9ca88f1e7c9312ea70674cec3af360c994762309f6323730525e92c77d2715ee5f08aa8f438b7ca18efe378af647f501fc92b15b8e4b3b52d09db4
-  languageName: node
-  linkType: hard
-
-"ansi-colors@npm:^4.1.1":
-  version: 4.1.3
-  resolution: "ansi-colors@npm:4.1.3"
-  checksum: 10/43d6e2fc7b1c6e4dc373de708ee76311ec2e0433e7e8bd3194e7ff123ea6a747428fc61afdcf5969da5be3a5f0fd054602bec56fc0ebe249ce2fcde6e649e3c2
   languageName: node
   linkType: hard
 
@@ -10511,7 +10473,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array-includes@npm:^3.1.3, array-includes@npm:^3.1.6, array-includes@npm:^3.1.8":
+"array-includes@npm:^3.1.6, array-includes@npm:^3.1.8":
   version: 3.1.8
   resolution: "array-includes@npm:3.1.8"
   dependencies:
@@ -10588,7 +10550,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array.prototype.flat@npm:^1.2.4, array.prototype.flat@npm:^1.3.1, array.prototype.flat@npm:^1.3.2":
+"array.prototype.flat@npm:^1.3.1, array.prototype.flat@npm:^1.3.2":
   version: 1.3.3
   resolution: "array.prototype.flat@npm:1.3.3"
   dependencies:
@@ -10600,7 +10562,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array.prototype.flatmap@npm:^1.2.4, array.prototype.flatmap@npm:^1.3.2, array.prototype.flatmap@npm:^1.3.3":
+"array.prototype.flatmap@npm:^1.3.2, array.prototype.flatmap@npm:^1.3.3":
   version: 1.3.3
   resolution: "array.prototype.flatmap@npm:1.3.3"
   dependencies:
@@ -10802,13 +10764,6 @@ __metadata:
   version: 1.0.0
   resolution: "astral-regex@npm:1.0.0"
   checksum: 10/93417fc0879531cd95ace2560a54df865c9461a3ac0714c60cbbaa5f1f85d2bee85489e78d82f70b911b71ac25c5f05fc5a36017f44c9bb33c701bee229ff848
-  languageName: node
-  linkType: hard
-
-"astral-regex@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "astral-regex@npm:2.0.0"
-  checksum: 10/876231688c66400473ba505731df37ea436e574dd524520294cc3bbc54ea40334865e01fa0d074d74d036ee874ee7e62f486ea38bc421ee8e6a871c06f011766
   languageName: node
   linkType: hard
 
@@ -11582,7 +11537,6 @@ __metadata:
     sharp: "npm:^0.30.4"
     socket.io-client: "npm:^2.3.1"
     socket.io-emitter: "npm:^3.1.1"
-    standard: "npm:16.0.4"
     stream-buffers: "npm:^3.0.2"
     stripe: "npm:^6.15.0"
     uuid: "npm:^9.0.0"
@@ -14955,7 +14909,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:*, debug@npm:4, debug@npm:^4.0.1, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.5, debug@npm:^4.3.7":
+"debug@npm:*, debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.5, debug@npm:^4.3.7":
   version: 4.4.0
   resolution: "debug@npm:4.4.0"
   dependencies:
@@ -16164,16 +16118,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enquirer@npm:^2.3.5":
-  version: 2.4.1
-  resolution: "enquirer@npm:2.4.1"
-  dependencies:
-    ansi-colors: "npm:^4.1.1"
-    strip-ansi: "npm:^6.0.1"
-  checksum: 10/b3726486cd98f0d458a851a03326a2a5dd4d84f37ff94ff2a2960c915e0fc865865da3b78f0877dc36ac5c1189069eca603e82ec63d5bc6b0dd9985bf6426d7a
-  languageName: node
-  linkType: hard
-
 "ent@npm:^2.2.0":
   version: 2.2.2
   resolution: "ent@npm:2.2.2"
@@ -16622,16 +16566,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-config-standard-jsx@npm:10.0.0":
-  version: 10.0.0
-  resolution: "eslint-config-standard-jsx@npm:10.0.0"
-  peerDependencies:
-    eslint: ^7.12.1
-    eslint-plugin-react: ^7.21.5
-  checksum: 10/9cce2861461b4ead3dd984d6e71cdaa8bc377b9e3652dce231c558007eadeaa93d2e9ae9a1c2e8fdc2be9aab0274be72949fc5a223eaaadbadd41d4f408cd089
-  languageName: node
-  linkType: hard
-
 "eslint-config-standard-jsx@npm:^11.0.0":
   version: 11.0.0
   resolution: "eslint-config-standard-jsx@npm:11.0.0"
@@ -16653,18 +16587,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-config-standard@npm:16.0.3":
-  version: 16.0.3
-  resolution: "eslint-config-standard@npm:16.0.3"
-  peerDependencies:
-    eslint: ^7.12.1
-    eslint-plugin-import: ^2.22.1
-    eslint-plugin-node: ^11.1.0
-    eslint-plugin-promise: ^4.2.1 || ^5.0.0
-  checksum: 10/420b2b929576e5c4f96508cd6ae65744c51b80cc89db25eccfd673e16b68c6e200e27dc3dacb793aa7a46bbc4c579e85ea84882367974e0060672dc9ff49088a
-  languageName: node
-  linkType: hard
-
 "eslint-config-standard@npm:17.1.0, eslint-config-standard@npm:^17.1.0":
   version: 17.1.0
   resolution: "eslint-config-standard@npm:17.1.0"
@@ -16677,7 +16599,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-import-resolver-node@npm:^0.3.6, eslint-import-resolver-node@npm:^0.3.9":
+"eslint-import-resolver-node@npm:^0.3.9":
   version: 0.3.9
   resolution: "eslint-import-resolver-node@npm:0.3.9"
   dependencies:
@@ -16688,7 +16610,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-module-utils@npm:^2.12.0, eslint-module-utils@npm:^2.6.2, eslint-module-utils@npm:^2.9.0":
+"eslint-module-utils@npm:^2.12.0, eslint-module-utils@npm:^2.9.0":
   version: 2.12.0
   resolution: "eslint-module-utils@npm:2.12.0"
   dependencies:
@@ -16819,31 +16741,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-import@npm:~2.24.2":
-  version: 2.24.2
-  resolution: "eslint-plugin-import@npm:2.24.2"
-  dependencies:
-    array-includes: "npm:^3.1.3"
-    array.prototype.flat: "npm:^1.2.4"
-    debug: "npm:^2.6.9"
-    doctrine: "npm:^2.1.0"
-    eslint-import-resolver-node: "npm:^0.3.6"
-    eslint-module-utils: "npm:^2.6.2"
-    find-up: "npm:^2.0.0"
-    has: "npm:^1.0.3"
-    is-core-module: "npm:^2.6.0"
-    minimatch: "npm:^3.0.4"
-    object.values: "npm:^1.1.4"
-    pkg-up: "npm:^2.0.0"
-    read-pkg-up: "npm:^3.0.0"
-    resolve: "npm:^1.20.0"
-    tsconfig-paths: "npm:^3.11.0"
-  peerDependencies:
-    eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0
-  checksum: 10/f587b830c23ef8a1f7e057ea32be5d7c22d75ddad9801ec14081a0d3e7cfa4242920ecacb89dce789b530621c4ab9c6a701596d40a34883f41709739dcd125ea
-  languageName: node
-  linkType: hard
-
 "eslint-plugin-jest@npm:^26.5.3":
   version: 26.9.0
   resolution: "eslint-plugin-jest@npm:26.9.0"
@@ -16970,7 +16867,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-node@npm:^11.1.0, eslint-plugin-node@npm:~11.1.0":
+"eslint-plugin-node@npm:^11.1.0":
   version: 11.1.0
   resolution: "eslint-plugin-node@npm:11.1.0"
   dependencies:
@@ -17018,15 +16915,6 @@ __metadata:
   peerDependencies:
     eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
   checksum: 10/e7447159d52dbc0fdaacfad18571906bb783f9f41f497e73f9b0351e9cc79497f9a9053fbef8141d0c027c16c768a1ef7f8cd4709a4a5cbb14636e862a1ccb34
-  languageName: node
-  linkType: hard
-
-"eslint-plugin-promise@npm:~5.1.0":
-  version: 5.1.1
-  resolution: "eslint-plugin-promise@npm:5.1.1"
-  peerDependencies:
-    eslint: ^7.0.0
-  checksum: 10/e0264c53bf7c6df9d4bd3989e3570f631c0214709aac0ecc4995871914c8de47b2602d681a0d4a1c1774fd3fdcea104b93fdf9d5a9eafc9606191bcfcfc9cdb1
   languageName: node
   linkType: hard
 
@@ -17110,29 +16998,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react@npm:~7.25.1":
-  version: 7.25.3
-  resolution: "eslint-plugin-react@npm:7.25.3"
-  dependencies:
-    array-includes: "npm:^3.1.3"
-    array.prototype.flatmap: "npm:^1.2.4"
-    doctrine: "npm:^2.1.0"
-    estraverse: "npm:^5.2.0"
-    jsx-ast-utils: "npm:^2.4.1 || ^3.0.0"
-    minimatch: "npm:^3.0.4"
-    object.entries: "npm:^1.1.4"
-    object.fromentries: "npm:^2.0.4"
-    object.hasown: "npm:^1.0.0"
-    object.values: "npm:^1.1.4"
-    prop-types: "npm:^15.7.2"
-    resolve: "npm:^2.0.0-next.3"
-    string.prototype.matchall: "npm:^4.0.5"
-  peerDependencies:
-    eslint: ^3 || ^4 || ^5 || ^6 || ^7
-  checksum: 10/7065deb229d64e99ca8bb12230eca960b01dbc16b7a2581a548b038511d9ce047b55bf996a04f5efc1f94104030bff14d25ff6dda5ec8e6b029d5f08ba617855
-  languageName: node
-  linkType: hard
-
 "eslint-plugin-testing-library@npm:^6.2.2":
   version: 6.5.0
   resolution: "eslint-plugin-testing-library@npm:6.5.0"
@@ -17186,7 +17051,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-utils@npm:^2.0.0, eslint-utils@npm:^2.1.0":
+"eslint-utils@npm:^2.0.0":
   version: 2.1.0
   resolution: "eslint-utils@npm:2.1.0"
   dependencies:
@@ -17206,7 +17071,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-visitor-keys@npm:^1.1.0, eslint-visitor-keys@npm:^1.3.0":
+"eslint-visitor-keys@npm:^1.1.0":
   version: 1.3.0
   resolution: "eslint-visitor-keys@npm:1.3.0"
   checksum: 10/595ab230e0fcb52f86ba0986a9a473b9fcae120f3729b43f1157f88f27f8addb1e545c4e3d444185f2980e281ca15be5ada6f65b4599eec227cf30e41233b762
@@ -17376,53 +17241,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:~7.18.0":
-  version: 7.18.0
-  resolution: "eslint@npm:7.18.0"
-  dependencies:
-    "@babel/code-frame": "npm:^7.0.0"
-    "@eslint/eslintrc": "npm:^0.3.0"
-    ajv: "npm:^6.10.0"
-    chalk: "npm:^4.0.0"
-    cross-spawn: "npm:^7.0.2"
-    debug: "npm:^4.0.1"
-    doctrine: "npm:^3.0.0"
-    enquirer: "npm:^2.3.5"
-    eslint-scope: "npm:^5.1.1"
-    eslint-utils: "npm:^2.1.0"
-    eslint-visitor-keys: "npm:^2.0.0"
-    espree: "npm:^7.3.1"
-    esquery: "npm:^1.2.0"
-    esutils: "npm:^2.0.2"
-    file-entry-cache: "npm:^6.0.0"
-    functional-red-black-tree: "npm:^1.0.1"
-    glob-parent: "npm:^5.0.0"
-    globals: "npm:^12.1.0"
-    ignore: "npm:^4.0.6"
-    import-fresh: "npm:^3.0.0"
-    imurmurhash: "npm:^0.1.4"
-    is-glob: "npm:^4.0.0"
-    js-yaml: "npm:^3.13.1"
-    json-stable-stringify-without-jsonify: "npm:^1.0.1"
-    levn: "npm:^0.4.1"
-    lodash: "npm:^4.17.20"
-    minimatch: "npm:^3.0.4"
-    natural-compare: "npm:^1.4.0"
-    optionator: "npm:^0.9.1"
-    progress: "npm:^2.0.0"
-    regexpp: "npm:^3.1.0"
-    semver: "npm:^7.2.1"
-    strip-ansi: "npm:^6.0.0"
-    strip-json-comments: "npm:^3.1.0"
-    table: "npm:^6.0.4"
-    text-table: "npm:^0.2.0"
-    v8-compile-cache: "npm:^2.0.3"
-  bin:
-    eslint: bin/eslint.js
-  checksum: 10/86ab5f9e83efc6d0608c2a2725732f21e46233a31b8554fc9f1593fea871f8dbc09c997a68518323391e0d4396067072d1ee28d38912d2dcea8fbd772e2f530f
-  languageName: node
-  linkType: hard
-
 "esm@npm:^3.2.25":
   version: 3.2.25
   resolution: "esm@npm:3.2.25"
@@ -17438,17 +17256,6 @@ __metadata:
     acorn-jsx: "npm:^5.3.2"
     eslint-visitor-keys: "npm:^4.2.0"
   checksum: 10/3412d44d4204c9e29d6b5dd0277400cfa0cd68495dc09eae1b9ce79d0c8985c1c5cc09cb9ba32a1cd963f48a49b0c46bdb7736afe395a300aa6bb1c0d86837e8
-  languageName: node
-  linkType: hard
-
-"espree@npm:^7.3.0, espree@npm:^7.3.1":
-  version: 7.3.1
-  resolution: "espree@npm:7.3.1"
-  dependencies:
-    acorn: "npm:^7.4.0"
-    acorn-jsx: "npm:^5.3.1"
-    eslint-visitor-keys: "npm:^1.3.0"
-  checksum: 10/7cf230d4d726f6e2c53925566ef96e78a5656eb05adbb6cd493f863341e532b491b035db7a4ce292b70243bb727722acff98b66ae751888ee51791d8389c6819
   languageName: node
   linkType: hard
 
@@ -17493,7 +17300,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esquery@npm:^1.2.0, esquery@npm:^1.4.0, esquery@npm:^1.4.2, esquery@npm:^1.5.0":
+"esquery@npm:^1.4.0, esquery@npm:^1.4.2, esquery@npm:^1.5.0":
   version: 1.6.0
   resolution: "esquery@npm:1.6.0"
   dependencies:
@@ -17970,13 +17777,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:^3.0.1":
-  version: 3.0.6
-  resolution: "fast-uri@npm:3.0.6"
-  checksum: 10/43c87cd03926b072a241590e49eca0e2dfe1d347ddffd4b15307613b42b8eacce00a315cf3c7374736b5f343f27e27ec88726260eb03a758336d507d6fbaba0a
-  languageName: node
-  linkType: hard
-
 "fast-xml-parser@npm:^4.2.5, fast-xml-parser@npm:^4.4.1":
   version: 4.5.1
   resolution: "fast-xml-parser@npm:4.5.1"
@@ -18045,7 +17845,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"file-entry-cache@npm:^6.0.0, file-entry-cache@npm:^6.0.1":
+"file-entry-cache@npm:^6.0.1":
   version: 6.0.1
   resolution: "file-entry-cache@npm:6.0.1"
   dependencies:
@@ -18309,15 +18109,6 @@ __metadata:
     path-exists: "npm:^2.0.0"
     pinkie-promise: "npm:^2.0.0"
   checksum: 10/a2cb9f4c9f06ee3a1e92ed71d5aed41ac8ae30aefa568132f6c556fac7678a5035126153b59eaec68da78ac409eef02503b2b059706bdbf232668d7245e3240a
-  languageName: node
-  linkType: hard
-
-"find-up@npm:^2.0.0, find-up@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "find-up@npm:2.1.0"
-  dependencies:
-    locate-path: "npm:^2.0.0"
-  checksum: 10/43284fe4da09f89011f08e3c32cd38401e786b19226ea440b75386c1b12a4cb738c94969808d53a84f564ede22f732c8409e3cfc3f7fb5b5c32378ad0bbf28bd
   languageName: node
   linkType: hard
 
@@ -19140,7 +18931,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob-parent@npm:^5.0.0, glob-parent@npm:^5.1.2, glob-parent@npm:~5.1.2":
+"glob-parent@npm:^5.1.2, glob-parent@npm:~5.1.2":
   version: 5.1.2
   resolution: "glob-parent@npm:5.1.2"
   dependencies:
@@ -19323,15 +19114,6 @@ __metadata:
   version: 11.12.0
   resolution: "globals@npm:11.12.0"
   checksum: 10/9f054fa38ff8de8fa356502eb9d2dae0c928217b8b5c8de1f09f5c9b6c8a96d8b9bd3afc49acbcd384a98a81fea713c859e1b09e214c60509517bb8fc2bc13c2
-  languageName: node
-  linkType: hard
-
-"globals@npm:^12.1.0":
-  version: 12.4.0
-  resolution: "globals@npm:12.4.0"
-  dependencies:
-    type-fest: "npm:^0.8.1"
-  checksum: 10/11b38ef0077f5d8d616b1bc5effac20667247fc42c65c6f8fac4fc3758cd14ad73ccd36eff376c29ef395caf5f4c33e8460b78f79c37ce44cf3ab568a3b7623b
   languageName: node
   linkType: hard
 
@@ -19828,13 +19610,6 @@ __metadata:
     is-number: "npm:^3.0.0"
     kind-of: "npm:^4.0.0"
   checksum: 10/77e6693f732b5e4cf6c38dfe85fdcefad0fab011af74995c3e83863fabf5e3a836f406d83565816baa0bc0a523c9410db8b990fe977074d61aeb6d8f4fcffa11
-  languageName: node
-  linkType: hard
-
-"has@npm:^1.0.3":
-  version: 1.0.4
-  resolution: "has@npm:1.0.4"
-  checksum: 10/c245f332fe78c7b6b8753857240ac12b3286f995f656a33c77e0f5baab7d0157e6ddb1c34940ffd2bffc51f75ede50cd8b29ff65c13e336376aca8cf3df58043
   languageName: node
   linkType: hard
 
@@ -20454,13 +20229,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore@npm:^4.0.6":
-  version: 4.0.6
-  resolution: "ignore@npm:4.0.6"
-  checksum: 10/e04d6bd60d9da12cfe8896acf470824172843dddc25a9be0726199d5e031254634a69ce8479a82f194154b9b28cb3b08bb7a53e56f7f7eba2663e04791e74742
-  languageName: node
-  linkType: hard
-
 "ignore@npm:^5.0.5, ignore@npm:^5.1.1, ignore@npm:^5.2.0, ignore@npm:^5.3.1, ignore@npm:^5.3.2":
   version: 5.3.2
   resolution: "ignore@npm:5.3.2"
@@ -20906,7 +20674,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-core-module@npm:^2.11.0, is-core-module@npm:^2.13.0, is-core-module@npm:^2.15.1, is-core-module@npm:^2.16.0, is-core-module@npm:^2.5.0, is-core-module@npm:^2.6.0":
+"is-core-module@npm:^2.11.0, is-core-module@npm:^2.13.0, is-core-module@npm:^2.15.1, is-core-module@npm:^2.16.0, is-core-module@npm:^2.5.0":
   version: 2.16.1
   resolution: "is-core-module@npm:2.16.1"
   dependencies:
@@ -23100,13 +22868,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-schema-traverse@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "json-schema-traverse@npm:1.0.0"
-  checksum: 10/02f2f466cdb0362558b2f1fd5e15cce82ef55d60cd7f8fa828cf35ba74330f8d767fcae5c5c2adb7851fa811766c694b9405810879bc4e1ddd78a7c0e03658ad
-  languageName: node
-  linkType: hard
-
 "json-schema@npm:0.4.0":
   version: 0.4.0
   resolution: "json-schema@npm:0.4.0"
@@ -23859,18 +23620,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"load-json-file@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "load-json-file@npm:4.0.0"
-  dependencies:
-    graceful-fs: "npm:^4.1.2"
-    parse-json: "npm:^4.0.0"
-    pify: "npm:^3.0.0"
-    strip-bom: "npm:^3.0.0"
-  checksum: 10/8f5d6d93ba64a9620445ee9bde4d98b1eac32cf6c8c2d20d44abfa41a6945e7969456ab5f1ca2fb06ee32e206c9769a20eec7002fe290de462e8c884b6b8b356
-  languageName: node
-  linkType: hard
-
 "load-json-file@npm:^5.2.0":
   version: 5.3.0
   resolution: "load-json-file@npm:5.3.0"
@@ -23914,16 +23663,6 @@ __metadata:
   version: 0.2.4
   resolution: "localized-strings@npm:0.2.4"
   checksum: 10/934b892516d92d94985dcf933b0d01720df1b613267bb3510a6f466f2e0d6f4c66d246f90f33d1b5fbc38147cfd521f0fc7ffd8a894d51ca3b6eb99910e26d39
-  languageName: node
-  linkType: hard
-
-"locate-path@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "locate-path@npm:2.0.0"
-  dependencies:
-    p-locate: "npm:^2.0.0"
-    path-exists: "npm:^3.0.0"
-  checksum: 10/02d581edbbbb0fa292e28d96b7de36b5b62c2fa8b5a7e82638ebb33afa74284acf022d3b1e9ae10e3ffb7658fbc49163fcd5e76e7d1baaa7801c3e05a81da755
   languageName: node
   linkType: hard
 
@@ -24145,13 +23884,6 @@ __metadata:
   version: 4.5.1
   resolution: "lodash.trimstart@npm:4.5.1"
   checksum: 10/66280d921c5221aed6bc96d698923c6d7eb97aa14923ff528ae6ffb5454eee495e8a3c1525ca149d85c428543b014ca141c31f6021ac1cd444aa54f1f7f398a6
-  languageName: node
-  linkType: hard
-
-"lodash.truncate@npm:^4.4.2":
-  version: 4.4.2
-  resolution: "lodash.truncate@npm:4.4.2"
-  checksum: 10/7a495616121449e5d2288c606b1025d42ab9979e8c93ba885e5c5802ffd4f1ebad4428c793ccc12f73e73237e85a9f5b67dd6415757546fbd5a4653ba83e25ac
   languageName: node
   linkType: hard
 
@@ -25721,7 +25453,6 @@ __metadata:
     reselect-tools: "npm:^0.0.7"
     sails.io.js: "npm:^1.2.1"
     socket.io-client: "npm:2.3.1"
-    standard: "npm:^17.1.2"
     tailwind-merge: "npm:^2.5.4"
     tailwindcss: "npm:^3.4.17"
     timezone-mock: "npm:^1.3.6"
@@ -26730,7 +26461,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.entries@npm:^1.1.4, object.entries@npm:^1.1.8":
+"object.entries@npm:^1.1.8":
   version: 1.1.8
   resolution: "object.entries@npm:1.1.8"
   dependencies:
@@ -26741,7 +26472,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.fromentries@npm:^2.0.4, object.fromentries@npm:^2.0.8":
+"object.fromentries@npm:^2.0.8":
   version: 2.0.8
   resolution: "object.fromentries@npm:2.0.8"
   dependencies:
@@ -26779,17 +26510,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.hasown@npm:^1.0.0":
-  version: 1.1.4
-  resolution: "object.hasown@npm:1.1.4"
-  dependencies:
-    define-properties: "npm:^1.2.1"
-    es-abstract: "npm:^1.23.2"
-    es-object-atoms: "npm:^1.0.0"
-  checksum: 10/797385577b3ef3c0d19333e03ed34bc7987978ae1ee1245069c9922e17d1128265187f729dc610260d03f8d418af26fcd7919b423793bf0af9099d9f08367d69
-  languageName: node
-  linkType: hard
-
 "object.map@npm:^1.0.0":
   version: 1.0.1
   resolution: "object.map@npm:1.0.1"
@@ -26819,7 +26539,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.values@npm:^1.1.4, object.values@npm:^1.1.6, object.values@npm:^1.2.0, object.values@npm:^1.2.1":
+"object.values@npm:^1.1.6, object.values@npm:^1.2.0, object.values@npm:^1.2.1":
   version: 1.2.1
   resolution: "object.values@npm:1.2.1"
   dependencies:
@@ -27090,15 +26810,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-limit@npm:^1.1.0":
-  version: 1.3.0
-  resolution: "p-limit@npm:1.3.0"
-  dependencies:
-    p-try: "npm:^1.0.0"
-  checksum: 10/eb9d9bc378d48ab1998d2a2b2962a99eddd3e3726c82d3258ecc1a475f22907968edea4fec2736586d100366a001c6bb449a2abe6cd65e252e9597394f01e789
-  languageName: node
-  linkType: hard
-
 "p-limit@npm:^2.0.0, p-limit@npm:^2.2.0":
   version: 2.3.0
   resolution: "p-limit@npm:2.3.0"
@@ -27114,15 +26825,6 @@ __metadata:
   dependencies:
     yocto-queue: "npm:^0.1.0"
   checksum: 10/7c3690c4dbf62ef625671e20b7bdf1cbc9534e83352a2780f165b0d3ceba21907e77ad63401708145ca4e25bfc51636588d89a8c0aeb715e6c37d1c066430360
-  languageName: node
-  linkType: hard
-
-"p-locate@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "p-locate@npm:2.0.0"
-  dependencies:
-    p-limit: "npm:^1.1.0"
-  checksum: 10/e2dceb9b49b96d5513d90f715780f6f4972f46987dc32a0e18bc6c3fc74a1a5d73ec5f81b1398af5e58b99ea1ad03fd41e9181c01fa81b4af2833958696e3081
   languageName: node
   linkType: hard
 
@@ -27193,13 +26895,6 @@ __metadata:
   dependencies:
     p-finally: "npm:^1.0.0"
   checksum: 10/3dd0eaa048780a6f23e5855df3dd45c7beacff1f820476c1d0d1bcd6648e3298752ba2c877aa1c92f6453c7dd23faaf13d9f5149fc14c0598a142e2c5e8d649c
-  languageName: node
-  linkType: hard
-
-"p-try@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "p-try@npm:1.0.0"
-  checksum: 10/20d9735f57258158df50249f172c77fe800d31e80f11a3413ac9e68ccbe6b11798acb3f48f2df8cea7ba2b56b753ce695a4fe2a2987c3c7691c44226b6d82b6f
   languageName: node
   linkType: hard
 
@@ -27777,15 +27472,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-type@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "path-type@npm:3.0.0"
-  dependencies:
-    pify: "npm:^3.0.0"
-  checksum: 10/735b35e256bad181f38fa021033b1c33cfbe62ead42bb2222b56c210e42938eecb272ae1949f3b6db4ac39597a61b44edd8384623ec4d79bfdc9a9c0f12537a6
-  languageName: node
-  linkType: hard
-
 "path-type@npm:^4.0.0":
   version: 4.0.0
   resolution: "path-type@npm:4.0.0"
@@ -28062,15 +27748,6 @@ __metadata:
   dependencies:
     find-up: "npm:^4.0.0"
   checksum: 10/9863e3f35132bf99ae1636d31ff1e1e3501251d480336edb1c211133c8d58906bed80f154a1d723652df1fda91e01c7442c2eeaf9dc83157c7ae89087e43c8d6
-  languageName: node
-  linkType: hard
-
-"pkg-up@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "pkg-up@npm:2.0.0"
-  dependencies:
-    find-up: "npm:^2.1.0"
-  checksum: 10/de4b418175281a082e366ce1a919f032520ee53cf421578b35173f03816f6ec4c19e1552066840bb0988c3e1215859653948efd6ca3507a23f4f44229269500d
   languageName: node
   linkType: hard
 
@@ -29029,7 +28706,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"progress@npm:^2.0.0, progress@npm:^2.0.3":
+"progress@npm:^2.0.3":
   version: 2.0.3
   resolution: "progress@npm:2.0.3"
   checksum: 10/e6f0bcb71f716eee9dfac0fe8a2606e3704d6a64dd93baaf49fbadbc8499989a610fe14cf1bc6f61b6d6653c49408d94f4a94e124538084efd8e4cf525e0293d
@@ -31117,16 +30794,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"read-pkg-up@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "read-pkg-up@npm:3.0.0"
-  dependencies:
-    find-up: "npm:^2.0.0"
-    read-pkg: "npm:^3.0.0"
-  checksum: 10/16175573f2914ab9788897bcbe2a62b5728d0075e62285b3680cebe97059e2911e0134a062cf6e51ebe3e3775312bc788ac2039ed6af38ec68d2c10c6f2b30fb
-  languageName: node
-  linkType: hard
-
 "read-pkg-up@npm:^7.0.1":
   version: 7.0.1
   resolution: "read-pkg-up@npm:7.0.1"
@@ -31146,17 +30813,6 @@ __metadata:
     normalize-package-data: "npm:^2.3.2"
     path-type: "npm:^1.0.0"
   checksum: 10/a0f5d5e32227ec8e6a028dd5c5134eab229768dcb7a5d9a41a284ed28ad4b9284fecc47383dc1593b5694f4de603a7ffaee84b738956b9b77e0999567485a366
-  languageName: node
-  linkType: hard
-
-"read-pkg@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "read-pkg@npm:3.0.0"
-  dependencies:
-    load-json-file: "npm:^4.0.0"
-    normalize-package-data: "npm:^2.3.2"
-    path-type: "npm:^3.0.0"
-  checksum: 10/398903ebae6c7e9965419a1062924436cc0b6f516c42c4679a90290d2f87448ed8f977e7aa2dbba4aa1ac09248628c43e493ac25b2bc76640e946035200e34c6
   languageName: node
   linkType: hard
 
@@ -31637,7 +31293,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regexpp@npm:^3.0.0, regexpp@npm:^3.1.0, regexpp@npm:^3.2.0":
+"regexpp@npm:^3.0.0, regexpp@npm:^3.2.0":
   version: 3.2.0
   resolution: "regexpp@npm:3.2.0"
   checksum: 10/3310010895a906873262f4b494fc99bcef1e71ef6720a0532c5999ca586498cbd4a284c8e3c2423f9d1d37512fd08d6064b7564e0e59508cf938f76dd15ace84
@@ -31805,13 +31461,6 @@ __metadata:
   version: 2.1.1
   resolution: "require-directory@npm:2.1.1"
   checksum: 10/a72468e2589270d91f06c7d36ec97a88db53ae5d6fe3787fadc943f0b0276b10347f89b363b2a82285f650bdcc135ad4a257c61bdd4d00d6df1fa24875b0ddaf
-  languageName: node
-  linkType: hard
-
-"require-from-string@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "require-from-string@npm:2.0.2"
-  checksum: 10/839a3a890102a658f4cb3e7b2aa13a1f80a3a976b512020c3d1efc418491c48a886b6e481ea56afc6c4cb5eef678f23b2a4e70575e7534eccadf5e30ed2e56eb
   languageName: node
   linkType: hard
 
@@ -31993,7 +31642,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^2.0.0-next.3, resolve@npm:^2.0.0-next.5":
+"resolve@npm:^2.0.0-next.5":
   version: 2.0.0-next.5
   resolution: "resolve@npm:2.0.0-next.5"
   dependencies:
@@ -32019,7 +31668,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A^2.0.0-next.3#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^2.0.0-next.5#optional!builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A^2.0.0-next.5#optional!builtin<compat/resolve>":
   version: 2.0.0-next.5
   resolution: "resolve@patch:resolve@npm%3A2.0.0-next.5#optional!builtin<compat/resolve>::version=2.0.0-next.5&hash=c3c19d"
   dependencies:
@@ -32311,6 +31960,7 @@ __metadata:
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
     "@hylo/shared": "workspace:*"
+    standard: "npm:^17.1.2"
     typescript: "npm:5.0.4"
   languageName: unknown
   linkType: soft
@@ -32795,7 +32445,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.0.0, semver@npm:^7.1.3, semver@npm:^7.2.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.0, semver@npm:^7.6.3":
+"semver@npm:^7.0.0, semver@npm:^7.1.3, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.0, semver@npm:^7.6.3":
   version: 7.6.3
   resolution: "semver@npm:7.6.3"
   bin:
@@ -33337,17 +32987,6 @@ __metadata:
     astral-regex: "npm:^1.0.0"
     is-fullwidth-code-point: "npm:^2.0.0"
   checksum: 10/4e82995aa59cef7eb03ef232d73c2239a15efa0ace87a01f3012ebb942e963fbb05d448ce7391efcd52ab9c32724164aba2086f5143e0445c969221dde3b6b1e
-  languageName: node
-  linkType: hard
-
-"slice-ansi@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "slice-ansi@npm:4.0.0"
-  dependencies:
-    ansi-styles: "npm:^4.0.0"
-    astral-regex: "npm:^2.0.0"
-    is-fullwidth-code-point: "npm:^3.0.0"
-  checksum: 10/4a82d7f085b0e1b070e004941ada3c40d3818563ac44766cca4ceadd2080427d337554f9f99a13aaeb3b4a94d9964d9466c807b3d7b7541d1ec37ee32d308756
   languageName: node
   linkType: hard
 
@@ -33912,18 +33551,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"standard-engine@npm:^14.0.1":
-  version: 14.0.1
-  resolution: "standard-engine@npm:14.0.1"
-  dependencies:
-    get-stdin: "npm:^8.0.0"
-    minimist: "npm:^1.2.5"
-    pkg-conf: "npm:^3.1.0"
-    xdg-basedir: "npm:^4.0.0"
-  checksum: 10/56942f6c6d7996646ca7e6f115ea42fdb7b31cc6bd753b81e7211efa25901617afad319352da57039035c42f8aa4fb20f7e21fe4df693f017f39b74be7c82e68
-  languageName: node
-  linkType: hard
-
 "standard-engine@npm:^15.1.0":
   version: 15.1.0
   resolution: "standard-engine@npm:15.1.0"
@@ -33936,25 +33563,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"standard@npm:16.0.4, standard@npm:^16.0.4":
-  version: 16.0.4
-  resolution: "standard@npm:16.0.4"
-  dependencies:
-    eslint: "npm:~7.18.0"
-    eslint-config-standard: "npm:16.0.3"
-    eslint-config-standard-jsx: "npm:10.0.0"
-    eslint-plugin-import: "npm:~2.24.2"
-    eslint-plugin-node: "npm:~11.1.0"
-    eslint-plugin-promise: "npm:~5.1.0"
-    eslint-plugin-react: "npm:~7.25.1"
-    standard-engine: "npm:^14.0.1"
-  bin:
-    standard: bin/cmd.js
-  checksum: 10/6d1305dfa0b160fefdd92fef6ba44eac94ea2f74b3c275b9574e6ca694d11fbebee97d1ebb3bf075d2f4e926ab104dec424555c805cb464016b42be93f1e63e1
-  languageName: node
-  linkType: hard
-
-"standard@npm:17.1.2, standard@npm:^17.1.2":
+"standard@npm:^17.1.2":
   version: 17.1.2
   resolution: "standard@npm:17.1.2"
   dependencies:
@@ -34212,7 +33821,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string.prototype.matchall@npm:^4.0.12, string.prototype.matchall@npm:^4.0.5":
+"string.prototype.matchall@npm:^4.0.12":
   version: 4.0.12
   resolution: "string.prototype.matchall@npm:4.0.12"
   dependencies:
@@ -34717,19 +34326,6 @@ __metadata:
   version: 3.2.4
   resolution: "symbol-tree@npm:3.2.4"
   checksum: 10/c09a00aadf279d47d0c5c46ca3b6b2fbaeb45f0a184976d599637d412d3a70bbdc043ff33effe1206dea0e36e0ad226cb957112e7ce9a4bf2daedf7fa4f85c53
-  languageName: node
-  linkType: hard
-
-"table@npm:^6.0.4":
-  version: 6.9.0
-  resolution: "table@npm:6.9.0"
-  dependencies:
-    ajv: "npm:^8.0.1"
-    lodash.truncate: "npm:^4.4.2"
-    slice-ansi: "npm:^4.0.0"
-    string-width: "npm:^4.2.3"
-    strip-ansi: "npm:^6.0.1"
-  checksum: 10/976da6d89841566e39628d1ba107ffab126964c9390a0a877a7c54ebb08820bf388d28fe9f8dcf354b538f19634a572a506c38a3762081640013a149cc862af9
   languageName: node
   linkType: hard
 
@@ -35453,7 +35049,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsconfig-paths@npm:^3.11.0, tsconfig-paths@npm:^3.15.0":
+"tsconfig-paths@npm:^3.15.0":
   version: 3.15.0
   resolution: "tsconfig-paths@npm:3.15.0"
   dependencies:
@@ -37029,7 +36625,6 @@ __metadata:
     scroll-into-view-if-needed: "npm:^2.2.29"
     slick-carousel: "npm:^1.8.1"
     socket.io-client: "npm:2.3.1"
-    standard: "npm:17.1.2"
     streamifier: "npm:^0.1.1"
     supercluster: "npm:^7.0.0"
     tailwind-merge: "npm:^2.5.4"


### PR DESCRIPTION
This is all superficial, I promise nothing to fret about. 

- The only things that could have a consequence is the StandardJS move to global, which should be the right direction for our monorepo but may have an edge or two to file off. For now works great for making VS Code linting happy, and does ensure we're on the same version of Standard across all code bases. 

- Switches from requires to imports for `@graphql-yoga/node` in the Backend. Because we can (earlier versions were presumably not Modules compatible), and eventually if we've moved all our requires to imports we can switch the Backend to modules which would simplify our shared code, amongst other things. 

- Some auto lint fixes applied to some Backend code on files I was already touching. 