### PR TITLE
chore(mobile): Fixes various issues with changing groups, adds Zustand dependency

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -109,7 +109,8 @@
     "socket.io-client": "2.3.1",
     "tailwindcss": "^3.4.17",
     "tinycolor2": "^1.6.0",
-    "urql": "^4.2.1"
+    "urql": "^4.2.1",
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/apps/mobile/src/components/HyloHTML/HyloHTML.js
+++ b/apps/mobile/src/components/HyloHTML/HyloHTML.js
@@ -3,7 +3,6 @@ import { useWindowDimensions } from 'react-native'
 import { RenderHTMLConfigProvider, RenderHTMLSource } from 'react-native-render-html'
 import WebView from 'react-native-webview'
 import iframe, { iframeModel } from '@native-html/iframe-plugin'
-import useCurrentGroup from 'hooks/useCurrentGroup'
 import { openURL } from 'hooks/useOpenURL'
 import useGoToMember from 'hooks/useGoToMember'
 import useGoToTopic from 'hooks/useGoToTopic'
@@ -71,12 +70,7 @@ const renderers = {
 }
 
 export function HyloHTMLConfigProvider ({ children }) {
-  const [{ currentGroup }] = useCurrentGroup()
-
-  const handleLinkPress = useCallback(
-    async (_, href) => openURL(href),
-    [currentGroup?.slug]
-  )
+  const handleLinkPress = async (_, href) => openURL(href)
 
   const renderersProps = useMemo(() => ({
     a: { onPress: handleLinkPress },

--- a/apps/mobile/src/hooks/useChangeToGroup.js
+++ b/apps/mobile/src/hooks/useChangeToGroup.js
@@ -1,16 +1,16 @@
 import { useNavigation } from '@react-navigation/native'
 import { useTranslation } from 'react-i18next'
 import confirmNavigate from 'util/confirmNavigate'
-import useCurrentGroup from 'hooks/useCurrentGroup'
-import useCurrentUser from 'hooks/useCurrentUser'
-import { ALL_GROUP_ID, PUBLIC_GROUP_ID } from 'urql-shared/presenters/GroupPresenter'
 import { modalScreenName } from 'hooks/useIsModalScreen'
+import { isContextGroup } from 'urql-shared/presenters/GroupPresenter'
+import { useCurrentGroupSlug } from 'hooks/useCurrentGroup'
+import useCurrentUser from 'hooks/useCurrentUser'
 
 export default function useChangeToGroup () {
   const { t } = useTranslation()
   const navigation = useNavigation()
   const [{ currentUser }] = useCurrentUser()
-  const [{ currentGroup }] = useCurrentGroup()
+  const [{ currentGroupSlug }] = useCurrentGroupSlug()
   const myMemberships = currentUser?.memberships
 
   return (groupSlug, confirm = true) => {
@@ -18,10 +18,10 @@ export default function useChangeToGroup () {
       throw new Error('Must provide current user memberships as 2nd parameter')
     }
 
-    if (groupSlug === currentGroup?.slug) return
+    if (groupSlug === currentGroupSlug) return
 
-    const canViewGroup = myMemberships.find(m => m.group.slug === groupSlug) ||
-      [PUBLIC_GROUP_ID, ALL_GROUP_ID].includes(groupSlug)
+    const canViewGroup = myMemberships.find(m => m.group.slug === groupSlug)
+      || isContextGroup(groupSlug)
 
     if (canViewGroup) {
       const goToGroup = () => {

--- a/apps/mobile/src/screens/ChatRoomWebView/ChatRoomWebView.js
+++ b/apps/mobile/src/screens/ChatRoomWebView/ChatRoomWebView.js
@@ -45,7 +45,7 @@ export default function ChatRoom () {
 
   return (
     <KeyboardFriendlyView style={{ flex: 1 }}>
-      <GroupWelcomeCheck groupId={currentGroup?.id} />
+      <GroupWelcomeCheck />
       <HyloWebView
         handledWebRoutes={handledWebRoutes}
         nativeRouteHandler={nativeRouteHandler}

--- a/apps/mobile/src/screens/GroupNavigation/GroupNavigation.js
+++ b/apps/mobile/src/screens/GroupNavigation/GroupNavigation.js
@@ -15,8 +15,7 @@ export default function GroupNavigation () {
   const { t } = useTranslation()
   const navigation = useNavigation()
   const { myHome, groupSlug } = useRouteParams()
-  const [{ currentGroup: currentGroupRaw, fetching }] = useCurrentGroup({ setToGroupSlug: groupSlug })
-  const currentGroup = GroupPresenter(currentGroupRaw)
+  const [{ currentGroup, fetching }] = useCurrentGroup({ setToGroupSlug: groupSlug })
 
   const childGroups = currentGroup?.childGroups?.items
   const parentGroups = currentGroup?.parentGroups?.items

--- a/apps/mobile/src/screens/Stream/Stream.js
+++ b/apps/mobile/src/screens/Stream/Stream.js
@@ -160,7 +160,7 @@ export default function Stream ({ topicName: providedTopicName }) {
 
   return (
     <>
-      <GroupWelcomeCheck groupId={currentGroup?.id} />
+      <GroupWelcomeCheck />
       {streamType !== 'moderation' && (
         <StreamList
           scrollRef={ref}

--- a/apps/mobile/src/urql-shared/presenters/GroupPresenter.js
+++ b/apps/mobile/src/urql-shared/presenters/GroupPresenter.js
@@ -138,8 +138,8 @@ export const ALL_GROUP = {
   avatarUrl: Image.resolveAssetSource(allGroupsAvatarUrl).uri,
   bannerUrl: Image.resolveAssetSource(allGroupsBannerImage).uri,
   name: 'All My Groups',
-  parentGroups: { toModelArray: () => [] },
-  childGroups: { toModelArray: () => [] }
+  parentGroups: { items: [], hasMore: false, total: 0 },
+  childGroups: { items: [], hasMore: false, total: 0 }
 }
 
 export const PUBLIC_GROUP_ID = PUBLIC_CONTEXT_SLUG
@@ -150,8 +150,8 @@ export const PUBLIC_GROUP = {
   avatarUrl: Image.resolveAssetSource(publicGroupAvatarUrl).uri,
   bannerUrl: Image.resolveAssetSource(GREEN_HERO_BANNER_PATH).uri,
   name: 'Public Stream',
-  parentGroups: { toModelArray: () => [] },
-  childGroups: { toModelArray: () => [] }
+  parentGroups: { items: [], hasMore: false, total: 0 },
+  childGroups: { items: [], hasMore: false, total: 0 }
 }
 
 export const MY_CONTEXT_ID = 'my'
@@ -163,10 +163,16 @@ export const MY_CONTEXT_GROUP = {
   avatarUrl: Image.resolveAssetSource(myHomeAvatarUrl).uri,
   bannerUrl: Image.resolveAssetSource(PURPLE_HERO_BANNER_PATH).uri,
   name: 'My Home',
-  parentGroups: { toModelArray: () => [] },
-  childGroups: { toModelArray: () => [] }
+  parentGroups: { items: [], hasMore: false, total: 0 },
+  childGroups: { items: [], hasMore: false, total: 0 }
 }
 
-// TODO: URQL - Move into hylo-shared (PathsHelper?)
 export const isContextGroup = slug =>
   [ALL_GROUPS_CONTEXT_SLUG, PUBLIC_CONTEXT_SLUG, MY_CONTEXT_SLUG].includes(slug)
+
+export function getContextGroup (groupSlug, groupId) {
+  if (groupId === ALL_GROUP_ID || groupSlug === ALL_GROUP_ID) return ALL_GROUP
+  if (groupId === PUBLIC_GROUP_ID || groupSlug === PUBLIC_GROUP_ID) return PUBLIC_GROUP
+  if (groupId === MY_CONTEXT_ID || groupSlug === MY_CONTEXT_ID) return MY_CONTEXT_GROUP
+  return null
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -25460,6 +25460,7 @@ __metadata:
     typescript: "npm:5.0.4"
     urql: "npm:^4.2.1"
     validator: "npm:^13.12.0"
+    zustand: "npm:^5.0.3"
   languageName: unknown
   linkType: soft
 
@@ -37686,5 +37687,26 @@ __metadata:
   version: 0.1.5
   resolution: "zstd-codec@npm:0.1.5"
   checksum: 10/deee384c29129e3ed86b4f2ac4dc415fd8dad8b62b12ad07cc092c89481bee362477478c6179f2beb252bec67b57120fad8fd84f0a7f7b5914a77e24b3608094
+  languageName: node
+  linkType: hard
+
+"zustand@npm:^5.0.3":
+  version: 5.0.3
+  resolution: "zustand@npm:5.0.3"
+  peerDependencies:
+    "@types/react": ">=18.0.0"
+    immer: ">=9.0.6"
+    react: ">=18.0.0"
+    use-sync-external-store: ">=1.2.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    immer:
+      optional: true
+    react:
+      optional: true
+    use-sync-external-store:
+      optional: true
+  checksum: 10/35728fdaa68291ea3e469524316dda4fe1d8cc22d8be3df309ca99bda0dbc7e66a1c502f66c26f76abfb4bd49a6e1368160353eb3cb173c24042a5f252075462
   languageName: node
   linkType: hard


### PR DESCRIPTION
This is a weird set of things that all came-up during debugging navigating between Context Group (My, Public, All) and normal groups. There were some persistent React errors and crashes coming up around hook state (returning before all hooks ran). This fixes those. 

Also this branch adds Zustand as a dependency which I now use as a local store for currentGroupSlug (useCurrentGroup, useCurrentGroupSlug, etc). It is much easier to work with than our Redux setup, even in the bare non ReduxORM state, and I intend to convert the other bits of state still in Redux to Zustand useState bit by bit. I do think it will be useful for some work coming up. There is no issue with having it in place while keeping Redux as it is for now.