### PR TITLE
return to prev location on post modal close

### DIFF
--- a/apps/web/src/components/CreateModal/CreateModal.js
+++ b/apps/web/src/components/CreateModal/CreateModal.js
@@ -1,7 +1,9 @@
 import React, { useRef, useState } from 'react'
+import { useSelector } from 'react-redux'
 import { Route, Routes, useNavigate, useLocation } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { CSSTransition } from 'react-transition-group'
+import getPreviousLocation from 'store/selectors/getPreviousLocation'
 import CreateModalChooser from './CreateModalChooser'
 import CreateGroup from 'components/CreateGroup'
 import Icon from 'components/Icon'
@@ -14,6 +16,8 @@ const CreateModal = (props) => {
   const [isDirty, setIsDirty] = useState()
   const { t } = useTranslation()
   const modalRef = useRef(null)
+  const previousLocation = useSelector(getPreviousLocation) || { pathname: '/' }
+  const [returnToLocation] = useState(previousLocation)
 
   const querystringParams = new URLSearchParams(location.search)
   const mapLocation = (querystringParams.has('lat') && querystringParams.has('lng'))
@@ -21,7 +25,7 @@ const CreateModal = (props) => {
     : null
 
   const closeModal = () => {
-    navigate(location.pathname.replace(/\/create.*/, ''))
+    navigate(returnToLocation)
   }
 
   const confirmClose = () => {


### PR DESCRIPTION
Addresses [this comment](https://github.com/Hylozoic/hylo/commit/092d0fe548efa80dd605c5a6a17310674fbcc1e6#diff-48894935b7df20376b9be76d5f6165169d86ae2faacda6cd702f56a5385eb2d9R24) 

When editing a post, the modal cannot close because there is no "create" in the URL. So the URL doesn't change and therefore the modal doesn't close.

This is because the post edit function uses the CreateModal component. We can have two modals, one for create and one for edit, I suppose, but this PR seems to work.

**Is there an edge case that this PR is not addressing?**