### PR TITLE
Styles ItemSelector Modal, and properly handles safe are insets

### DIFF
--- a/apps/mobile/src/components/ImageViewer/ImageViewer.js
+++ b/apps/mobile/src/components/ImageViewer/ImageViewer.js
@@ -7,7 +7,7 @@ import {
   TouchableOpacity,
   TouchableHighlight
 } from 'react-native'
-import { SafeAreaView } from 'react-native-safe-area-context'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import Avatar from 'components/Avatar'
 import ImageView from 'react-native-image-viewing'
 import { rhino30, white } from 'style/colors'
@@ -104,43 +104,40 @@ export default function ImageViewer ({
 }
 
 const ImageViewerHeader = ({ creator, onRequestClose, title }) => {
+  const insets = useSafeAreaInsets()
   return (
-    <SafeAreaView style={headerStyles.root}>
-      <View style={headerStyles.container}>
-        <View style={headerStyles.postDetails}>
-          <View style={headerStyles.postDetailsTop}>
-            {creator && (
-              <>
-                <Avatar avatarUrl={creator.avatarUrl} dimension={28} />
-                <View style={headerStyles.postDetailsNameAndDate}>
-                  <Text style={headerStyles.postDetailsName}>{creator.name}</Text>
-                  {/* <Text style={headerStyles.postDetailsDate}>3w ago</Text> */}
-                </View>
-              </>
-            )}
-          </View>
-          {title && (
-            <Text style={headerStyles.postDetailsTitle}>{title}</Text>
+    <View style={[headerStyles.container, { paddingTop: insets.top }]}>
+      <View style={headerStyles.postDetails}>
+        <View style={headerStyles.postDetailsTop}>
+          {creator && (
+            <>
+              <Avatar avatarUrl={creator.avatarUrl} dimension={28} />
+              <View style={headerStyles.postDetailsNameAndDate}>
+                <Text style={headerStyles.postDetailsName}>{creator.name}</Text>
+                {/* <Text style={headerStyles.postDetailsDate}>3w ago</Text> */}
+              </View>
+            </>
           )}
         </View>
-        <TouchableOpacity
-          style={headerStyles.closeButton}
-          onPress={onRequestClose}
-          hitSlop={{ top: 16, left: 16, bottom: 16, right: 16 }}
-        >
-          <Text style={headerStyles.closeText}>✕</Text>
-        </TouchableOpacity>
+        {title && (
+          <Text style={headerStyles.postDetailsTitle}>{title}</Text>
+        )}
       </View>
-    </SafeAreaView>
+      <TouchableOpacity
+        style={headerStyles.closeButton}
+        onPress={onRequestClose}
+        hitSlop={{ top: 16, left: 16, bottom: 16, right: 16 }}
+      >
+        <Text style={headerStyles.closeText}>✕</Text>
+      </TouchableOpacity>
+    </View>
   )
 }
 
 const headerStyles = StyleSheet.create({
-  root: {
-    backgroundColor: '#00000077'
-  },
   container: {
     flex: 1,
+    backgroundColor: '#00000077',
     padding: 15,
     paddingBottom: 10,
     paddingTop: 10,
@@ -190,10 +187,11 @@ const headerStyles = StyleSheet.create({
 })
 
 export const ImageViewerFooter = ({ imageIndex, imagesCount }) => {
+  const insets = useSafeAreaInsets()
   if (imagesCount < 2) return null
 
   return (
-    <View style={footerStyles.root}>
+    <View style={[footerStyles.root, { paddingBottom: insets.bottom }]}>
       <Text style={footerStyles.text}>{`${imageIndex + 1} / ${imagesCount}`}</Text>
     </View>
   )

--- a/apps/mobile/src/components/ItemSelectorModal/ItemSelectorModal.js
+++ b/apps/mobile/src/components/ItemSelectorModal/ItemSelectorModal.js
@@ -5,10 +5,10 @@ import { useQuery } from 'urql'
 import { isEmpty, isFunction, debounce } from 'lodash/fp'
 import getFirstRootField from '@hylo/urql/getFirstRootFieldFromData'
 import Avatar from 'components/Avatar'
+import Icon from 'components/Icon'
 import RoundCheckbox from 'components/RoundCheckBox'
 import SearchBar from 'components/SearchBar'
-import { havelockBlue, rhino80, rhino50, caribbeanGreen, rhino10, capeCod10, alabaster, rhino } from 'style/colors'
-import Icon from 'components/Icon'
+import { havelockBlue, rhino80, rhino50, caribbeanGreen, alabaster, rhino60 } from 'style/colors'
 
 const ItemSelectorModalHeader = ({
   onClose,
@@ -254,7 +254,7 @@ export const ItemSelectorModal = React.forwardRef(({
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: rhino,
+    backgroundColor: rhino60,
     margin: 30,
     borderRadius: 20,
     padding: 10

--- a/apps/mobile/src/components/ItemSelectorModal/ItemSelectorModal.js
+++ b/apps/mobile/src/components/ItemSelectorModal/ItemSelectorModal.js
@@ -1,19 +1,22 @@
 import React, { useEffect, useState, useImperativeHandle, useCallback, useMemo } from 'react'
 import { View, Modal, FlatList, Text, TouchableOpacity, StyleSheet } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useQuery } from 'urql'
 import { isEmpty, isFunction, debounce } from 'lodash/fp'
 import getFirstRootField from '@hylo/urql/getFirstRootFieldFromData'
 import Avatar from 'components/Avatar'
 import RoundCheckbox from 'components/RoundCheckBox'
 import SearchBar from 'components/SearchBar'
-import { havelockBlue, rhino80, rhino50, white, caribbeanGreen, rhino10 } from 'style/colors'
+import { havelockBlue, rhino80, rhino50, caribbeanGreen, rhino10, capeCod10, alabaster, rhino } from 'style/colors'
+import Icon from 'components/Icon'
 
-// TODO: URQL! Finish styling this modal component
 const ItemSelectorModalHeader = ({
+  onClose,
   searchTerm,
   headerText,
   setSearchTerm,
   searchPlaceholder,
+  title,
   autoFocus = false,
   onFocus,
   loading
@@ -24,12 +27,17 @@ const ItemSelectorModalHeader = ({
 
   return (
     <View style={styles.listHeader}>
+      <TouchableOpacity onPress={onClose} style={styles.title}>
+        <Icon name='Ex' style={styles.closeButton} />
+        {title && <Text style={styles.titleText}>{title}</Text>}
+      </TouchableOpacity>
       <SearchBar
-        style={styles.searchBar}
+        style={{ container: styles.searchBar, searchInput: styles.searchInput }}
         autoFocus={autoFocus}
         onFocus={onFocus}
         value={searchTerm}
         onChangeText={setSearchTerm}
+        onClose={onClose}
         placeholder={searchPlaceholder}
         onCancel={clearSearchTerm}
         onCancelText='Clear'
@@ -81,11 +89,13 @@ export const ItemSelectorModal = React.forwardRef(({
   itemsUseQueryArgs: providedItemsUseQueryArgs,
   itemsUseQuerySelector = getFirstRootField,
   searchPlaceholder,
+  title,
   initialSearchTerm,
   // Turn on to have multiple selections
   chooser = false
 }, ref) => {
   const [visible, setVisible] = useState(false)
+  const insets = useSafeAreaInsets()
 
   const [items, setItems] = useState(defaultItems)
   const [chosenItems, setChosenItems] = useState(providedChosenItems || [])
@@ -212,15 +222,21 @@ export const ItemSelectorModal = React.forwardRef(({
   }, [handleItemPress, isChosen, handleToggleChosen])
 
   return (
-    <Modal visible={visible} animationType='slide' onRequestClose={handleOnClose}>
-      <View style={styles.container}>
-        <TouchableOpacity style={styles.closeButton} onPress={handleOnClose}>
-          <Text style={styles.closeText}>Close</Text>
-        </TouchableOpacity>
+    <Modal visible={visible} animationType='slide' onRequestClose={handleOnClose} transparent>
+      <View
+        style={[
+          styles.container, {
+            marginTop: styles.container.margin + insets.top,
+            marginBottom: (styles.container.margin * 2) + insets.bottom + 60
+          }
+        ]}
+      >
         <ItemSelectorModalHeader
+          onClose={handleOnClose}
           setSearchTerm={setSearchTerm}
           searchTerm={searchTerm}
           searchPlaceholder={searchPlaceholder}
+          title={title}
         />
         {fetching
           ? <Text>Loading...</Text>
@@ -238,21 +254,18 @@ export const ItemSelectorModal = React.forwardRef(({
 
 const styles = StyleSheet.create({
   container: {
-    paddingTop: 50,
-    flex: 1
-  },
-  content: {
-    flex: 1
+    backgroundColor: rhino,
+    margin: 30,
+    borderRadius: 20,
+    padding: 10
   },
   closeButton: {
-    marginBottom: 10,
-    padding: 10,
-    backgroundColor: '#ccc',
-    borderRadius: 5
-  },
-  closeText: {
-    fontSize: 16,
-    color: '#333'
+    // marginBottom: 10,
+    padding: 3,
+    borderRadius: 5,
+    fontSize: 22,
+    color: alabaster,
+    textAlign: 'left'
   },
 
   // Default Item
@@ -262,19 +275,19 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'flex-start',
     borderBottomWidth: 1,
-    borderBottomColor: rhino10
+    borderBottomColor: rhino80
   },
   itemAvatar: {
     marginRight: 12
   },
   itemName: {
+    color: alabaster,
     fontFamily: 'Circular-Bold',
     flex: 1
   },
 
   // From ItemChooser, for reference
   sectionHeader: {
-    backgroundColor: 'white',
     paddingHorizontal: 10,
     paddingTop: 10
   },
@@ -286,8 +299,21 @@ const styles = StyleSheet.create({
   sectionFooter: {
     marginBottom: 40
   },
+  title: {
+    flexGrow: 1,
+    flexShrink: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    // backgroundColor: rhino80,
+    padding: 3
+  },
+  titleText: {
+    color: alabaster,
+    fontSize: 18,
+    fontWeight: 'bold',
+    fontFamily: 'Circular-Book'
+  },
   listHeader: {
-    backgroundColor: white
   },
   listHeaderStatus: {
     paddingHorizontal: 10,
@@ -308,11 +334,15 @@ const styles = StyleSheet.create({
     color: havelockBlue
   },
   itemList: {
-    backgroundColor: white,
     marginBottom: 50
   },
   searchBar: {
-    margin: 10
+    marginTop: 5,
+    marginBottom: 5,
+    marginHorizontal: 10
+  },
+  searchInput: {
+    color: alabaster
   }
 })
 

--- a/apps/mobile/src/components/ItemSelectorModal/ItemSelectorModal.js
+++ b/apps/mobile/src/components/ItemSelectorModal/ItemSelectorModal.js
@@ -8,7 +8,7 @@ import Avatar from 'components/Avatar'
 import Icon from 'components/Icon'
 import RoundCheckbox from 'components/RoundCheckBox'
 import SearchBar from 'components/SearchBar'
-import { havelockBlue, rhino80, rhino50, caribbeanGreen, alabaster, rhino60 } from 'style/colors'
+import { havelockBlue, rhino80, rhino50, caribbeanGreen, alabaster, rhino } from 'style/colors'
 
 const ItemSelectorModalHeader = ({
   onClose,
@@ -254,7 +254,7 @@ export const ItemSelectorModal = React.forwardRef(({
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: rhino60,
+    backgroundColor: rhino,
     margin: 30,
     borderRadius: 20,
     padding: 10

--- a/apps/mobile/src/components/LocationSelectorModal/LocationSelectorModalItemRow.js
+++ b/apps/mobile/src/components/LocationSelectorModal/LocationSelectorModalItemRow.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { Text, TouchableOpacity } from 'react-native'
 import Icon from 'components/Icon'
 import useFindOrCreateLocationObject from 'components/LocationSelectorModal/useFindOrCreateLocationObject'
-import { rhino80, rhino20, caribbeanGreen, alabaster, rhino60 } from 'style/colors'
+import { rhino80, rhino20, caribbeanGreen, alabaster } from 'style/colors'
 
 export default function LocationSelectorModalItemRow ({ item, onPress }) {
   const [, findOrCreateLocationObject] = useFindOrCreateLocationObject()

--- a/apps/mobile/src/components/LocationSelectorModal/LocationSelectorModalItemRow.js
+++ b/apps/mobile/src/components/LocationSelectorModal/LocationSelectorModalItemRow.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { Text, TouchableOpacity } from 'react-native'
 import Icon from 'components/Icon'
 import useFindOrCreateLocationObject from 'components/LocationSelectorModal/useFindOrCreateLocationObject'
-import { rhino80, rhino20, caribbeanGreen } from 'style/colors'
+import { rhino80, rhino20, caribbeanGreen, alabaster, rhino60 } from 'style/colors'
 
 export default function LocationSelectorModalItemRow ({ item, onPress }) {
   const [, findOrCreateLocationObject] = useFindOrCreateLocationObject()
@@ -37,23 +37,21 @@ export default function LocationSelectorModalItemRow ({ item, onPress }) {
 
 const styles = {
   locationRow: {
-    paddingHorizontal: 13,
-    paddingTop: 13,
-    marginTop: 13,
+    padding: 10,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'flex-start',
     borderTopWidth: 1,
-    borderTopColor: rhino20
+    borderTopColor: rhino80
   },
   notGeocodedRow: {
-    color: rhino80
+    color: rhino20
   },
   locationIcon: {
     marginRight: 10
   },
   locationText: {
-    color: caribbeanGreen,
+    color: alabaster,
     fontWeight: 'normal',
     fontFamily: 'Circular-Bold',
     flex: 1

--- a/apps/mobile/src/components/MemberList/MemberList.js
+++ b/apps/mobile/src/components/MemberList/MemberList.js
@@ -168,7 +168,7 @@ export default function MemberList ({
         <SearchBar
           placeholder={t('Search Members')}
           onChangeText={handleSearch}
-          style={styles.searchWrapper}
+          style={{ container: styles.searchWrapper }}
         />
         {!hideSortOptions && (
           <PopupMenuButton actions={actions} style={styles.sortBy}>

--- a/apps/mobile/src/components/SearchBar/SearchBar.js
+++ b/apps/mobile/src/components/SearchBar/SearchBar.js
@@ -1,13 +1,8 @@
 import React from 'react'
-import {
-  View,
-  TouchableOpacity,
-  TextInput,
-  Text
-} from 'react-native'
+import { View, TouchableOpacity, TextInput, Text, StyleSheet } from 'react-native'
 import Icon from 'components/Icon'
-import styles from './SearchBar.styles'
 import Loading from 'components/Loading'
+import { rhino50, havelockBlue } from 'style/colors'
 
 export default function SearchBar ({
   value,
@@ -26,12 +21,12 @@ export default function SearchBar ({
     : <Icon name='Ex' style={styles.cancelButton} />
 
   return (
-    <View style={[styles.searchBar, style]}>
+    <View style={[styles.container, style.container]}>
       <Icon style={styles.searchIcon} name='Search' />
       <TextInput
         autoFocus={autoFocus}
         onFocus={onFocus}
-        style={styles.searchInput}
+        style={[styles.searchInput, style.searchInput]}
         value={value}
         onChangeText={onChangeText}
         placeholder={placeholder}
@@ -49,3 +44,48 @@ export default function SearchBar ({
     </View>
   )
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    flexShrink: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderWidth: 1,
+    padding: 3,
+    borderColor: rhino50,
+    borderRadius: 32
+  },
+  searchIcon: {
+    marginLeft: 2,
+    fontSize: 30,
+    color: rhino50,
+    backgroundColor: 'transparent'
+  },
+  searchInput: {
+    margin: 0,
+    padding: 0,
+    top: 1,
+    fontSize: 14,
+    fontFamily: 'Circular-Book',
+    flex: 1
+  },
+  loading: {
+    paddingHorizontal: 10
+  },
+  cancel: {
+    display: 'flex',
+    alignItems: 'center',
+    flexDirection: 'row',
+    paddingHorizontal: 10
+  },
+  cancelButton: {
+    fontSize: 20
+  },
+  cancelText: {
+    marginLeft: 'auto',
+    fontWeight: 'bold',
+    fontSize: 14,
+    color: havelockBlue
+  }
+})

--- a/apps/mobile/src/screens/LoadingScreen.js
+++ b/apps/mobile/src/screens/LoadingScreen.js
@@ -1,12 +1,14 @@
 import React from 'react'
-import { SafeAreaView } from 'react-native-safe-area-context'
+import { View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import Loading from 'components/Loading'
 
 export default function LoadingScreen () {
+  const insets = useSafeAreaInsets()
   return (
-    <SafeAreaView style={styles.container}>
+    <View style={[styles.container, { paddingBottom: insets.bottom, paddingTop: insets.top }]}>
       <Loading size='large' />
-    </SafeAreaView>
+    </View>
   )
 }
 

--- a/apps/mobile/src/screens/Login/Login.js
+++ b/apps/mobile/src/screens/Login/Login.js
@@ -3,7 +3,7 @@ import { ScrollView, Text, TextInput, TouchableOpacity, View } from 'react-nativ
 import { useTranslation } from 'react-i18next'
 import { useFocusEffect, useNavigation } from '@react-navigation/native'
 import FastImage from 'react-native-fast-image'
-import { SafeAreaView } from 'react-native-safe-area-context'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import EntypoIcon from 'react-native-vector-icons/Entypo'
 import { useAuth } from '@hylo/contexts/AuthContext'
 import useRouteParams from 'hooks/useRouteParams'
@@ -14,6 +14,7 @@ import styles from './Login.styles'
 import LocaleSelector from 'components/LocaleSelector/LocaleSelector'
 
 export default function Login () {
+  const insets = useSafeAreaInsets()
   const { t } = useTranslation()
   const navigation = useNavigation()
   const passwordInputRef = useRef()
@@ -93,7 +94,7 @@ export default function Login () {
   const goToResetPassword = () => navigation.navigate('ForgotPassword')
 
   return (
-    <SafeAreaView style={{ flex: 1 }} edges={['bottom', 'left', 'right']}>
+    <View style={{ flex: 1, paddingBottom: insets.bottom, paddingRight: insets.right, paddingLeft: insets.left }}>
       <ScrollView contentContainerStyle={styles.login} style={styles.container}>
         <View style={styles.localeContainer}>
           <View style={styles.localeContents}>
@@ -172,7 +173,7 @@ export default function Login () {
         <SocialAuth onStart={handleSocialAuthStart} onComplete={handleSocialAuthComplete} />
         <SignupLink goToSignup={goToSignup} />
       </ScrollView>
-    </SafeAreaView>
+    </View>
   )
 }
 

--- a/apps/mobile/src/screens/PostEditor/PostEditor.styles.js
+++ b/apps/mobile/src/screens/PostEditor/PostEditor.styles.js
@@ -1,3 +1,4 @@
+import { StyleSheet } from 'react-native'
 import { isIOS } from 'util/platform'
 import { POST_TYPES } from '@hylo/presenters/PostPresenter'
 import {
@@ -53,7 +54,7 @@ export const typeSelectorStyles = postType => ({
   }
 })
 
-export default {
+export const styles = StyleSheet.create({
   headerContainer: {
     height: 60,
     borderBottomWidth: 1,
@@ -262,4 +263,6 @@ export default {
   buttonBarAnnouncementIcon: {
     fontSize: 46
   }
-}
+})
+
+export default styles


### PR DESCRIPTION
We'll likely want to revisit the styling of this new do-everything modal selector in the near future, but this version is decent/releasable and easy to refine from here (some samples from PostEditor below). Also consistently applies useSafeAreaInsets in lieu of SafeAreaView component throughout app as recommended by React Navigation and elsewhere...

![Simulator Screenshot - iPhone 15 Pro Max - 2025-02-07 at 11 00 21](https://github.com/user-attachments/assets/f09d7c77-e862-443f-bba1-5978dd33ae92)
![Simulator Screenshot - iPhone 15 Pro Max - 2025-02-07 at 11 00 38](https://github.com/user-attachments/assets/23f4f049-bac0-4d2a-abe2-9ff0103565a3)
![Simulator Screenshot - iPhone 15 Pro Max - 2025-02-07 at 11 01 22](https://github.com/user-attachments/assets/9ee745ee-d0d9-4095-82b0-667eb6c0133e)

