### PR TITLE
add search to return url on close

### DIFF
--- a/apps/web/src/components/PostCard/PostHeader/PostHeader.connector.js
+++ b/apps/web/src/components/PostCard/PostHeader/PostHeader.connector.js
@@ -36,7 +36,7 @@ export function mapStateToProps (state, props) {
 
 export function mapDispatchToProps (dispatch, props) {
   const { groupSlug } = props.routeParams
-  const closeUrl = removePostFromUrl(window.location.pathname)
+  const closeUrl = removePostFromUrl(`${location.pathname}${location.search}`)
   const deletePostWithConfirm = (postId, groupId, text) => {
     if (window.confirm((text))) {
       dispatch(deletePost(postId, groupId))

--- a/apps/web/src/components/PostDialog/PostDialog.jsx
+++ b/apps/web/src/components/PostDialog/PostDialog.jsx
@@ -15,7 +15,7 @@ const PostDialog = ({
   const handleOpenChange = useCallback((open) => {
     if (!open) {
       // remove post/:postId from the url
-      navigate(removePostFromUrl(location.pathname))
+      navigate(removePostFromUrl(`${location.pathname}${location.search}`))
     }
   }, [])
 


### PR DESCRIPTION
closes #238

Kinda ugly but works to return back to viewmode from whence the user clicks the post (such as calendar but also applies to anything that isn't Card viewmode)

Also restores the sort/filter dropdown selection.