### PR TITLE
Improvements to post routing

### DIFF
--- a/apps/backend/api/models/FlaggedItem.js
+++ b/apps/backend/api/models/FlaggedItem.js
@@ -39,7 +39,7 @@ module.exports = bookshelf.Model.extend({
         return Frontend.Route.post(this.get('object_id'), group)
       case FlaggedItem.Type.COMMENT:
         const comment = await this.getObject()
-        return Frontend.Route.comment({ comment, groupSlug: group ? group.get('slug') : null })
+        return Frontend.Route.comment({ comment, group })
       case FlaggedItem.Type.MEMBER:
         return Frontend.Route.profile(this.get('object_id'), group)
       default:

--- a/apps/backend/api/models/Notification.js
+++ b/apps/backend/api/models/Notification.js
@@ -210,8 +210,7 @@ module.exports = bookshelf.Model.extend({
     const post = comment.relations.post
     const group = post.relations.groups.first()
     const locale = this.locale()
-    const groupSlug = getSlug(group)
-    const path = new URL(Frontend.Route.comment({ comment, groupSlug, post })).pathname
+    const path = new URL(Frontend.Route.comment({ comment, group, post })).pathname
     const alertText = PushNotification.textForComment(comment, version, locale)
     if (!this.reader().enabledNotification(TYPE.Comment, MEDIUM.Push)) {
       return Promise.resolve()

--- a/apps/backend/api/models/comment/notifications.js
+++ b/apps/backend/api/models/comment/notifications.js
@@ -133,7 +133,7 @@ export const sendDigests = async () => {
             count: commentData.length,
             post_title: post.summary(),
             post_creator_avatar_url: post.relations.user.get('avatar_url'),
-            thread_url: Frontend.Route.comment({ comment: commentData[0], groupSlug: firstGroup?.get('slug'), post }),
+            thread_url: Frontend.Route.comment({ comment: commentData[0], group: firstGroup, post }),
             comments: commentData,
             subject_prefix: some(hasMention, commentData)
               ? 'You were mentioned in'

--- a/apps/backend/api/services/Frontend.js
+++ b/apps/backend/api/services/Frontend.js
@@ -79,11 +79,9 @@ module.exports = {
 
     root: () => url('/app'),
 
-    comment: function ({ comment, groupSlug, post }) {
-      const groupUrl = isEmpty(groupSlug) ? '/all' : `/groups/${groupSlug}`
-
-      const postId = comment?.relations?.post?.id || post.id
-      return url(`${groupUrl}/post/${postId}/comments/${comment.id}`)
+    comment: function ({ comment, group, post }) {
+      const usePost = comment?.relations?.post || post
+      return this.post(usePost, group, `commentId=${comment.id}`)
     },
 
     group: function (group) {

--- a/apps/backend/test/unit/models/FlaggedItem.test.js
+++ b/apps/backend/test/unit/models/FlaggedItem.test.js
@@ -184,7 +184,7 @@ describe('FlaggedItem', () => {
       })
       const link = await flaggedItem.getContentLink(group)
 
-      expect(link).to.equal(Frontend.Route.comment({ post: commentParent, groupSlug: group.get('slug'), comment }))
+      expect(link).to.equal(Frontend.Route.comment({ post: commentParent, group, comment }))
     })
 
     it('throws an error when object_type is bad', () => {

--- a/apps/web/src/components/Calendar/body/day/calendar-body-day-event.tsx
+++ b/apps/web/src/components/Calendar/body/day/calendar-body-day-event.tsx
@@ -1,11 +1,9 @@
-import React, { useCallback } from 'react'
-import { useNavigate } from 'react-router'
-import { postUrl } from 'util/navigation'
-import { useCalendarContext } from 'components/Calendar/calendar-context'
+import React from 'react'
 import { DateTime } from 'luxon'
 import { cn } from '@/lib/utils'
 import { CalendarEvent as CalendarEventType } from 'components/Calendar/calendar-types'
 import Tooltip from 'components/Tooltip'
+import useViewPostDetails from 'hooks/useViewPostDetails'
 
 import classes from '../../calendar.module.scss'
 
@@ -14,12 +12,8 @@ export default function CalendarBodyDayEvent ({
 } : {
   event: CalendarEventType
 }) {
-  const { routeParams, locationParams, querystringParams } =
-    useCalendarContext()
-  const navigate = useNavigate()
-  const showDetails = useCallback(() => {
-    navigate(postUrl(event.id, routeParams, { ...locationParams, ...querystringParams }))
-  }, [event.id, routeParams, locationParams, querystringParams])
+  const viewPostDetails = useViewPostDetails()
+
   // TODO format for multi-day events
   const timeFormat = { ...DateTime.TIME_SIMPLE, timeZoneName: 'short' as const }
   const toolTipTitle = `${event.title}<br />${DateTime.fromJSDate(event.start).toLocaleString(timeFormat)} - ${DateTime.fromJSDate(event.end).toLocaleString(timeFormat)}`
@@ -30,7 +24,7 @@ export default function CalendarBodyDayEvent ({
         classes[event.type],
         'flex items-center gap-2 px-2 cursor-pointer rounded-md border-2'
       )}
-      onClick={showDetails}
+      onClick={() => viewPostDetails(event.id)}
       data-tooltip-id={`title-tip-${event.id}`} data-tooltip-html={toolTipTitle}
     >
       <div className='flex items-center gap-2'>

--- a/apps/web/src/components/Calendar/calendar-event.tsx
+++ b/apps/web/src/components/Calendar/calendar-event.tsx
@@ -1,13 +1,12 @@
-import React, { useCallback } from 'react'
-import { useNavigate } from 'react-router'
-import { CalendarEvent as CalendarEventType } from 'components/Calendar/calendar-types'
-import { postUrl } from 'util/navigation'
-import { useCalendarContext } from 'components/Calendar/calendar-context'
-import { DateTime } from 'luxon'
-import { cn } from '@/lib/utils'
 import { motion, MotionConfig, AnimatePresence } from 'framer-motion'
+import { DateTime } from 'luxon'
+import React from 'react'
+import { CalendarEvent as CalendarEventType } from 'components/Calendar/calendar-types'
+import { useCalendarContext } from 'components/Calendar/calendar-context'
 import Tooltip from 'components/Tooltip'
 import { sameDay, sameMonth } from './calendar-util'
+import useViewPostDetails from 'hooks/useViewPostDetails'
+import { cn } from 'util/index'
 
 import classes from './calendar.module.scss'
 
@@ -76,18 +75,13 @@ export default function CalendarEvent ({
   month?: boolean
   className?: string
 }) {
-  const { events, date, routeParams, locationParams, querystringParams } =
-    useCalendarContext()
+  const { events, date } = useCalendarContext()
   const style = month ? {} : calculateEventPosition(event, events)
   // TODO format for multi-day events
   const timeFormat = { ...DateTime.TIME_SIMPLE, timeZoneName: 'short' as const }
   const toolTipTitle = `${event.title}<br />${DateTime.fromJSDate(event.start).toLocaleString(timeFormat)} - ${DateTime.fromJSDate(event.end).toLocaleString(timeFormat)}`
 
-  // our custon event click handler
-  const navigate = useNavigate()
-  const showDetails = useCallback(() => {
-    navigate(postUrl(event.id, routeParams, { ...locationParams, ...querystringParams }))
-  }, [event.id, routeParams, locationParams, querystringParams])
+  const viewPostDetails = useViewPostDetails()
 
   // Generate a unique key that includes the current month to prevent animation conflicts
   const isEventInCurrentMonth = sameMonth(event.start, date)
@@ -108,7 +102,7 @@ export default function CalendarEvent ({
           style={style}
           onClick={(e) => {
             e.stopPropagation()
-            showDetails()
+            viewPostDetails(event)
           }}
           data-tooltip-id={`title-tip-${event.id}`} data-tooltip-html={toolTipTitle}
           initial={{

--- a/apps/web/src/components/Calendar/calendar-provider.tsx
+++ b/apps/web/src/components/Calendar/calendar-provider.tsx
@@ -4,9 +4,6 @@ import { CalendarEvent, Mode } from './calendar-types'
 
 export default function CalendarProvider ({
   events,
-  routeParams,
-  locationParams,
-  querystringParams,
   mode,
   setMode,
   date,
@@ -15,15 +12,6 @@ export default function CalendarProvider ({
   children
 }: {
   events: CalendarEvent[]
-  routeParams: {
-    [x: string]: string | string[];
-  }
-  locationParams: {
-    [x: string]: string | string[];
-  }
-  querystringParams: {
-    [x: string]: string | string[];
-  }
   mode: string
   setMode: (mode: Mode) => void
   date: Date
@@ -35,9 +23,6 @@ export default function CalendarProvider ({
     <CalendarContext.Provider
       value={{
         events,
-        routeParams,
-        locationParams,
-        querystringParams,
         mode,
         setMode,
         date,

--- a/apps/web/src/components/Calendar/calendar-types.ts
+++ b/apps/web/src/components/Calendar/calendar-types.ts
@@ -21,15 +21,6 @@ export type HyloPost = {
 export type CalendarProps = {
   posts?: HyloPost[]
   events?: CalendarEvent[]
-  routeParams: {
-    [x: string]: string | string[];
-  }
-  locationParams: {
-    [x: string]: string | string[];
-  }
-  querystringParams: {
-    [x: string]: string | string[];
-  }
   mode: string
   setMode: (mode: Mode) => void
   date: Date

--- a/apps/web/src/components/Calendar/calendar.tsx
+++ b/apps/web/src/components/Calendar/calendar.tsx
@@ -12,9 +12,6 @@ import { DateTime } from 'luxon'
 
 export default function Calendar ({
   posts,
-  routeParams,
-  locationParams,
-  querystringParams,
   calendarIconIsToday = true,
   date,
   setDate,
@@ -35,9 +32,6 @@ export default function Calendar ({
   return (
     <CalendarProvider
       events={events}
-      routeParams={routeParams}
-      locationParams={locationParams}
-      querystringParams={querystringParams}
       mode={mode}
       setMode={setMode}
       date={date}

--- a/apps/web/src/components/ModerationListItem/ModerationListItem.js
+++ b/apps/web/src/components/ModerationListItem/ModerationListItem.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
-import { Link, useLocation } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 
 import { agreementsURL, RESP_MANAGE_CONTENT } from 'store/constants'
 import getPlatformAgreements from 'store/selectors/getPlatformAgreements'

--- a/apps/web/src/components/PostBigGridItem/PostBigGridItem.js
+++ b/apps/web/src/components/PostBigGridItem/PostBigGridItem.js
@@ -2,7 +2,7 @@ import { cn } from 'util/index'
 import React, { useCallback } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import Avatar from 'components/Avatar'
 import EmojiRow from 'components/EmojiRow'
 import EventDate from 'components/PostCard/EventDate'
@@ -10,9 +10,10 @@ import EventRSVP from 'components/PostCard/EventRSVP'
 import HyloHTML from 'components/HyloHTML'
 import Icon from 'components/Icon'
 import Tooltip from 'components/Tooltip'
+import useViewPostDetails from 'hooks/useViewPostDetails'
 import respondToEvent from 'store/actions/respondToEvent'
 import getMe from 'store/selectors/getMe'
-import { personUrl, postUrl } from 'util/navigation'
+import { personUrl } from 'util/navigation'
 
 import classes from './PostBigGridItem.module.scss'
 
@@ -20,9 +21,7 @@ export default function PostBigGridItem ({
   childPost,
   currentGroupId,
   post,
-  expanded,
-  locationParams,
-  querystringParams
+  expanded
 }) {
   const {
     title,
@@ -33,7 +32,6 @@ export default function PostBigGridItem ({
   } = post
   const { t } = useTranslation()
   const routeParams = useParams()
-  const navigate = useNavigate()
   const dispatch = useDispatch()
   const numAttachments = attachments.length || 0
   const firstAttachment = attachments[0] || 0
@@ -43,10 +41,7 @@ export default function PostBigGridItem ({
   const isFlagged = post.flaggedGroups && post.flaggedGroups.includes(currentGroupId)
 
   const currentUser = useSelector(getMe)
-
-  const showDetails = useCallback(() => {
-    navigate(postUrl(post.id, routeParams, { ...locationParams, ...querystringParams }))
-  }, [post.id, routeParams, locationParams, querystringParams])
+  const viewPostDetails = useViewPostDetails()
 
   const handleRespondToEvent = useCallback((response) => {
     dispatch(respondToEvent(post, response))
@@ -75,10 +70,10 @@ export default function PostBigGridItem ({
   const donationService = d ? d[1] : null
 
   const showDetailsTargeted = () => {
-    return attachmentType === 'image' || post.type === 'event' ? showDetails() : null
+    return attachmentType === 'image' || post.type === 'event' ? viewPostDetails(post.id) : null
   }
   return (
-    <div className={cn(classes.postGridItemContainer, { [classes.unread]: unread, [classes.expanded]: expanded }, classes[attachmentType], classes[detailClass], classes[post.type])} onClick={attachmentType !== 'image' && post.type !== 'event' ? showDetails : null}>
+    <div className={cn(classes.postGridItemContainer, { [classes.unread]: unread, [classes.expanded]: expanded }, classes[attachmentType], classes[detailClass], classes[post.type])} onClick={attachmentType !== 'image' && post.type !== 'event' ? viewPostDetails(post.id) : null}>
       <div className={classes.contentSummary}>
         {childPost && (
           <div
@@ -104,7 +99,7 @@ export default function PostBigGridItem ({
         <h3 className={classes.title} onClick={showDetailsTargeted}>{title}</h3>
 
         {attachmentType === 'image'
-          ? <div style={{ backgroundImage: `url(${attachmentUrl})` }} className={cn(classes.firstImage, { [classes.isFlagged]: isFlagged && !post.clickthrough })} onClick={showDetails} />
+          ? <div style={{ backgroundImage: `url(${attachmentUrl})` }} className={cn(classes.firstImage, { [classes.isFlagged]: isFlagged && !post.clickthrough })} onClick={viewPostDetails(post)} />
           : null}
 
         {isFlagged && <Icon name='Flag' className={classes.flagIcon} />}
@@ -120,7 +115,7 @@ export default function PostBigGridItem ({
                 <EventDate {...post} />
               </div>
             )}
-            <h3 className={classes.title} onClick={showDetails}>{title}</h3>
+            <h3 className={classes.title} onClick={() => viewPostDetails(post)}>{title}</h3>
             <div className={classes.contentSnippet}>
               <HyloHTML className={classes.details} html={details} onClick={showDetailsTargeted} />
               <div className={classes.fade} />
@@ -156,7 +151,7 @@ export default function PostBigGridItem ({
                 </div>
               )}
             </div>
-            <div className={classes.author} onClick={showDetails}>
+            <div className={classes.author} onClick={() => viewPostDetails(post)}>
               <div className={classes.typeAuthor}>
                 <Avatar avatarUrl={creator.avatarUrl} url={creatorUrl} className={classes.avatar} tiny />
                 {creator.name}

--- a/apps/web/src/components/PostCard/PostCard.jsx
+++ b/apps/web/src/components/PostCard/PostCard.jsx
@@ -1,15 +1,13 @@
 import { get } from 'lodash/fp'
 import PropTypes from 'prop-types'
-import qs from 'query-string'
 import React, { useCallback, useRef } from 'react'
-import { useNavigate, useLocation } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useSelector, useDispatch } from 'react-redux'
 import CardImageAttachments from 'components/CardImageAttachments'
 import Icon from 'components/Icon'
 import useRouteParams from 'hooks/useRouteParams'
+import useViewPostDetails from 'hooks/useViewPostDetails'
 import { POST_PROP_TYPES } from 'store/models/Post'
-import { postUrl } from 'util/navigation'
 import respondToEvent from 'store/actions/respondToEvent'
 import getMe from 'store/selectors/getMe'
 import EventBody from './EventBody'
@@ -33,7 +31,6 @@ export default function PostCard (props) {
     group,
     mapDrawer,
     post,
-    locationParams,
     onAddReaction = () => {},
     onRemoveReaction = () => {}
   } = props
@@ -41,16 +38,11 @@ export default function PostCard (props) {
   const postCardRef = useRef()
   const { t } = useTranslation()
   const routeParams = useRouteParams()
-  const navigate = useNavigate()
   const dispatch = useDispatch()
-  const location = useLocation()
-  const querystringParams = qs.parse(location.search)
 
   const currentUser = useSelector(getMe)
 
-  const showDetails = useCallback(() => {
-    navigate(postUrl(post.id, routeParams, { ...locationParams, ...querystringParams }))
-  }, [post.id, routeParams, locationParams, querystringParams])
+  const viewPostDetails = useViewPostDetails()
 
   const handleRespondToEvent = useCallback((response) => {
     dispatch(respondToEvent(post, response))
@@ -72,8 +64,8 @@ export default function PostCard (props) {
   })
 
   const onClick = useCallback(event => {
-    if (shouldShowDetails(event.target)) showDetails()
-  })
+    if (shouldShowDetails(event.target)) viewPostDetails(post)
+  }, [post, viewPostDetails])
 
   const postType = get('type', post)
   const isEvent = postType === 'event'
@@ -103,7 +95,7 @@ export default function PostCard (props) {
       >
         <div onClick={onClick}>
           <PostHeader
-            {...post}
+            post={post}
             routeParams={routeParams}
             highlightProps={highlightProps}
             currentUser={currentUser}
@@ -172,6 +164,5 @@ PostCard.propTypes = {
   highlightProps: PropTypes.object,
   expanded: PropTypes.bool,
   constrained: PropTypes.bool,
-  className: PropTypes.string,
-  locationParams: PropTypes.object
+  className: PropTypes.string
 }

--- a/apps/web/src/components/PostCard/PostHeader/PostHeader.connector.js
+++ b/apps/web/src/components/PostCard/PostHeader/PostHeader.connector.js
@@ -17,7 +17,7 @@ import getRolesForGroup from 'store/selectors/getRolesForGroup'
 
 export function mapStateToProps (state, props) {
   const group = getGroup(state, props)
-  const url = postUrl(props.id, props.routeParams)
+  const url = postUrl(props.post.id, props.routeParams)
   const context = props.routeParams.context
   const currentUser = getMe(state, props)
   const responsibilities = getResponsibilitiesForGroup(state, { groupId: group?.id }).map(r => r.title)

--- a/apps/web/src/components/PostCard/PostHeader/PostHeader.js
+++ b/apps/web/src/components/PostCard/PostHeader/PostHeader.js
@@ -30,23 +30,14 @@ class PostHeader extends PureComponent {
   render () {
     const {
       routeParams,
+      post,
       canEdit,
-      creator,
-      createdTimestamp,
-      exactCreatedTimestamp,
       expanded,
-      group,
-      type,
-      id,
       isFlagged,
-      startTime,
       hasImage,
-      endTime,
-      fulfilledAt,
       proposalOutcome,
       proposalStatus,
       pinned,
-      topics,
       close,
       className,
       constrained,
@@ -57,13 +48,26 @@ class PostHeader extends PureComponent {
       pinPost,
       highlightProps,
       moderationActionsGroupUrl = '',
-      announcement,
       fulfillPost,
       unfulfillPost,
       updateProposalOutcome,
       postUrl,
       t
     } = this.props
+
+    const {
+      announcement,
+      creator,
+      createdTimestamp,
+      exactCreatedTimestamp,
+      group,
+      type,
+      id,
+      endTime,
+      startTime,
+      fulfilledAt,
+      topics
+    } = post
 
     if (!creator) return null
 

--- a/apps/web/src/components/PostGridItem/PostGridItem.js
+++ b/apps/web/src/components/PostGridItem/PostGridItem.js
@@ -1,22 +1,21 @@
-import React, { useCallback } from 'react'
-import { cn } from 'util/index'
-import Tooltip from 'components/Tooltip'
+import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { useNavigate } from 'react-router-dom'
-import { personUrl, postUrl } from 'util/navigation'
+import { personUrl } from 'util/navigation'
 import Avatar from 'components/Avatar'
 import HyloHTML from 'components/HyloHTML'
 import Icon from 'components/Icon'
+import Tooltip from 'components/Tooltip'
+import useRouteParams from 'hooks/useRouteParams'
+import useViewPostDetails from 'hooks/useViewPostDetails'
+import { cn } from 'util/index'
+
 import classes from './PostGridItem.module.scss'
 
 export default function PostGridItem ({
   childPost,
   currentGroupId,
-  routeParams,
   post,
-  expanded,
-  locationParams,
-  querystringParams
+  expanded
 }) {
   const {
     title,
@@ -26,7 +25,7 @@ export default function PostGridItem ({
     attachments
   } = post
 
-  const navigate = useNavigate()
+  const routeParams = useRouteParams()
 
   const numAttachments = attachments.length || 0
   const firstAttachment = attachments[0] || 0
@@ -39,12 +38,10 @@ export default function PostGridItem ({
   // will reintegrate once I have attachment vars
   /* const start = DateTime.fromISO(post.startTime) */
 
-  const showDetails = useCallback(() => {
-    navigate(postUrl(post.id, routeParams, { ...locationParams, ...querystringParams }))
-  }, [post.id, routeParams, locationParams, querystringParams])
+  const viewPostDetails = useViewPostDetails()
 
   return (
-    <div className={cn('h-[160px] w-full bg-background rounded-lg shadow-lg relative hover:scale-105 transition-all overflow-hidden', { [classes.unread]: unread, [classes.expanded]: expanded }, classes[attachmentType])} onClick={showDetails}>
+    <div className={cn('h-[160px] w-full bg-background rounded-lg shadow-lg relative hover:scale-105 transition-all overflow-hidden', { [classes.unread]: unread, [classes.expanded]: expanded }, classes[attachmentType])} onClick={() => viewPostDetails(post)}>
       <div className={classes.contentSummary}>
         {childPost &&
           <div

--- a/apps/web/src/components/PostListRow/PostListRow.js
+++ b/apps/web/src/components/PostListRow/PostListRow.js
@@ -1,8 +1,7 @@
 import { isEmpty } from 'lodash/fp'
 import { DateTime } from 'luxon'
-import qs from 'query-string'
-import React, { useCallback } from 'react'
-import { Link, useNavigate, useLocation } from 'react-router-dom'
+import React from 'react'
+import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 
 import Avatar from 'components/Avatar'
@@ -11,8 +10,9 @@ import HyloHTML from 'components/HyloHTML'
 import Icon from 'components/Icon'
 import Tooltip from 'components/Tooltip'
 import useRouteParams from 'hooks/useRouteParams'
+import useViewPostDetails from 'hooks/useViewPostDetails'
 import { cn } from 'util/index'
-import { personUrl, postUrl, topicUrl } from 'util/navigation'
+import { personUrl, topicUrl } from 'util/navigation'
 
 import classes from './PostListRow.module.scss'
 
@@ -38,14 +38,9 @@ const PostListRow = (props) => {
   } = post
 
   const { t } = useTranslation()
-  const navigate = useNavigate()
-  const location = useLocation()
   const routeParams = useRouteParams()
-  const querystringParams = qs.parse(location.search)
 
-  const showDetails = useCallback(() => {
-    navigate(postUrl(post.id, routeParams, querystringParams))
-  }, [post.id, routeParams, querystringParams])
+  const viewPostDetails = useViewPostDetails()
 
   if (!creator) { // PostCard guards against this, so it must be important? ;P
     return null
@@ -61,7 +56,7 @@ const PostListRow = (props) => {
   const isFlagged = post.flaggedGroups && post.flaggedGroups.includes(currentGroupId)
 
   return (
-    <div className={cn(classes.postRow, { [classes.unread]: unread, [classes.expanded]: expanded })} onClick={showDetails}>
+    <div className={cn(classes.postRow, { [classes.unread]: unread, [classes.expanded]: expanded })} onClick={() => viewPostDetails(post)}>
       <div className={classes.contentSummary}>
         <div className={classes.typeAuthor}>
           {isFlagged && <Icon name='Flag' className={classes.flagIcon} />}

--- a/apps/web/src/hooks/useRouteParams/index.js
+++ b/apps/web/src/hooks/useRouteParams/index.js
@@ -27,9 +27,9 @@ export default function useRouteParams () {
     const pathParts = location.pathname.split('/')
     // Correctly track the view
     if (params.context === 'groups') {
-      params.view = !['group', 'create'].includes(pathParts[3]) ? pathParts[3] : 'stream'
+      params.view = !['post', 'group', 'create'].includes(pathParts[3]) ? pathParts[3] : 'stream'
     } else {
-      params.view = !['group', 'create'].includes(pathParts[2]) ? pathParts[2] : 'stream'
+      params.view = !['post', 'group', 'create'].includes(pathParts[2]) ? pathParts[2] : 'stream'
     }
   }
 

--- a/apps/web/src/hooks/useViewPostDetails/index.js
+++ b/apps/web/src/hooks/useViewPostDetails/index.js
@@ -1,0 +1,20 @@
+import { get } from 'lodash/fp'
+import queryString from 'query-string'
+import { useCallback } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+import useRouteParams from 'hooks/useRouteParams'
+import { postUrl } from 'util/navigation'
+
+export default function useViewPostDetails () {
+  const routeParams = useRouteParams()
+  const location = useLocation()
+  const querystringParams = queryString.parse(location.search)
+  const navigate = useNavigate()
+
+  const viewPostDetails = useCallback((post) => {
+    const postId = get('id', post) || post
+    navigate(postUrl(postId, routeParams, querystringParams))
+  }, [routeParams, querystringParams])
+
+  return viewPostDetails
+}

--- a/apps/web/src/routes/AuthLayoutRouter/components/GlobalNav/NotificationsDropdown/NotificationsDropdown.store.js
+++ b/apps/web/src/routes/AuthLayoutRouter/components/GlobalNav/NotificationsDropdown/NotificationsDropdown.store.js
@@ -45,6 +45,11 @@ export function fetchNotifications (first = 20, offset = 0) {
                   id
                   slug
                 }
+                type
+                topics {
+                  id
+                  name
+                }
               }
               group {
                 id

--- a/apps/web/src/routes/ChatRoom/ChatRoom.js
+++ b/apps/web/src/routes/ChatRoom/ChatRoom.js
@@ -388,12 +388,12 @@ export default function ChatRoom (props) {
   if (topicFollowLoading) return <Loading />
 
   return (
-    <div className={cn('h-full shadow-md flex flex-col overflow-hidden items-center justify-center', { [styles.withoutNav]: withoutNav })}>
+    <div className={cn('h-full shadow-md flex flex-col overflow-hidden items-center justify-center', { [styles.withoutNav]: withoutNav })} ref={setContainer}>
       <Helmet>
         <title>#{topicName} | {group ? `${group.name} | ` : ''}Hylo</title>
       </Helmet>
 
-      <div id='chats' className='my-0 mx-auto h-[calc(100%-130px)] w-full flex flex-col flex-1 relative overflow-hidden' ref={setContainer}>
+      <div id='chats' className='my-0 mx-auto h-[calc(100%-130px)] w-full flex flex-col flex-1 relative overflow-hidden'>
         {initialPostToScrollTo === null
           ? <div className={styles.loadingContainer}><Loading /></div>
           : (

--- a/apps/web/src/routes/MapExplorer/MapDrawer/MapDrawer.js
+++ b/apps/web/src/routes/MapExplorer/MapDrawer/MapDrawer.js
@@ -27,7 +27,6 @@ function MapDrawer ({
   filters,
   group,
   groups = [],
-  locationParams,
   members = [],
   numFetchedPosts,
   numTotalPosts,
@@ -191,7 +190,6 @@ function MapDrawer ({
                     mapDrawer
                     expanded={false}
                     key={p.id}
-                    locationParams={locationParams}
                     group={group}
                     post={p}
                     className={styles.contentCard}

--- a/apps/web/src/routes/MapExplorer/MapExplorer.js
+++ b/apps/web/src/routes/MapExplorer/MapExplorer.js
@@ -343,11 +343,11 @@ function MapExplorer (props) {
     dispatch(saveSearch(attributes))
   }, [context, currentBoundingBox, currentUser?.id, dispatch, filters, groupSlug])
 
-  const showDetails = useCallback((postId) => dispatch(navigate(postUrl(postId, { ...routeParams, view: 'map' }, getQuerystringParam(['hideDrawer', 't', 'group'], location)))), [dispatch, navigate, routeParams, location])
+  const showDetails = useCallback((postId) => navigate(postUrl(postId, { ...routeParams, view: 'map' }, getQuerystringParam(['hideDrawer', 't', 'group'], location))), [navigate, routeParams, location])
 
-  const showGroupDetails = useCallback((groupSlug) => dispatch(navigate(groupDetailUrl(groupSlug, { ...routeParams, view: 'map' }, getQuerystringParam(['hideDrawer', 't', 'group'], location)))), [dispatch, navigate, routeParams, location])
+  const showGroupDetails = useCallback((groupSlug) => navigate(groupDetailUrl(groupSlug, { ...routeParams, view: 'map' }, getQuerystringParam(['hideDrawer', 't', 'group'], location))), [navigate, routeParams, location])
 
-  const gotoMember = useCallback((memberId) => dispatch(navigate(personUrl(memberId, groupSlug))), [dispatch, groupSlug, navigate])
+  const gotoMember = useCallback((memberId) => navigate(personUrl(memberId, groupSlug)), [dispatch, groupSlug, navigate])
 
   const toggleDrawer = useCallback(() => {
     dispatch(changeQuerystringParam(location, 'hideDrawer', !hideDrawer))

--- a/apps/web/src/routes/MapExplorer/MapExplorer.js
+++ b/apps/web/src/routes/MapExplorer/MapExplorer.js
@@ -695,8 +695,6 @@ function MapExplorer (props) {
   const { hideNavLayout } = layoutFlags
   const withoutNav = isWebView() || hideNavLayout
 
-  const locationParams = location !== undefined ? getQuerystringParam(['zoom', 'center', 'lat', 'lng'], location) : null
-
   return (
     <div className={cn(classes.container, { [classes.noUser]: !currentUser, [classes.withoutNav]: withoutNav })}>
       <Helmet>
@@ -735,7 +733,6 @@ function MapExplorer (props) {
           changeChildPostInclusion={changeChildPostInclusion}
           childPostInclusion={childPostInclusion}
           context={context}
-          locationParams={locationParams}
           currentUser={currentUser}
           fetchPostsForDrawer={doFetchPostsForDrawer}
           filters={filters}

--- a/apps/web/src/routes/MemberProfile/MemberProfile.js
+++ b/apps/web/src/routes/MemberProfile/MemberProfile.js
@@ -29,7 +29,7 @@ import PostDialog from 'components/PostDialog'
 import SkillsSection from 'components/SkillsSection'
 import SkillsToLearnSection from 'components/SkillsToLearnSection'
 import { useViewHeader } from 'contexts/ViewHeaderContext'
-
+import useViewPostDetails from 'hooks/useViewPostDetails'
 import blockUser from 'store/actions/blockUser'
 import { twitterUrl, AXOLOTL_ID } from 'store/models/Person'
 import getRolesForGroup from 'store/selectors/getRolesForGroup'
@@ -50,8 +50,7 @@ import {
   currentUserSettingsUrl,
   messagePersonUrl,
   messagesUrl,
-  gotoExternalUrl,
-  postUrl
+  gotoExternalUrl
 } from 'util/navigation'
 
 import styles from './MemberProfile.module.scss'
@@ -88,7 +87,6 @@ const MemberProfile = ({ currentTab = 'Overview', blockConfirmMessage, isSingleC
   const fetchPersonAction = (id) => dispatch(fetchPerson(id))
   const blockUserAction = (id) => dispatch(blockUser(id))
   const push = (url) => navigate(url)
-  const showDetails = (id, params) => navigate(postUrl(id, params))
   const goToPreviousLocation = () => navigate(previousLocation)
 
   const [currentTabState, setCurrentTabState] = useState(currentTab)
@@ -242,10 +240,10 @@ const MemberProfile = ({ currentTab = 'Overview', blockConfirmMessage, isSingleC
             {affiliations && affiliations.length > 0 && affiliations.map((a, index) => <Affiliation key={a.id} index={index} affiliation={a} />)}
 
             {events && events.length > 0 && <div className={styles.profileSubhead}>{t('Upcoming Events')}</div>}
-            {events && events.length > 0 && events.map((e, index) => <Event key={index} memberCap={3} event={e} routeParams={routeParams} showDetails={showDetails} />)}
+            {events && events.length > 0 && events.map((e, index) => <Event key={index} memberCap={3} event={e} routeParams={routeParams} />)}
 
             {projects && projects.length > 0 && <div className={styles.profileSubhead}>{t('Projects')}</div>}
-            {projects && projects.length > 0 && projects.map((p, index) => <Project key={index} memberCap={3} project={p} routeParams={routeParams} showDetails={showDetails} />)}
+            {projects && projects.length > 0 && projects.map((p, index) => <Project key={index} memberCap={3} project={p} routeParams={routeParams} />)}
           </div>
         </div>
         <div className='flex flex-col align-items-center max-w-[720px]'>
@@ -342,10 +340,11 @@ function ActionDropdown ({ items }) {
     />
 }
 
-function Project ({ memberCap, project, routeParams, showDetails }) {
-  const { title, id, createdAt, creator, members } = project
+function Project ({ memberCap, project }) {
+  const { title, createdAt, creator, members } = project
+  const viewPostDetails = useViewPostDetails()
   return (
-    <div className={styles.project} onClick={() => showDetails(id, { ...routeParams })}>
+    <div className={styles.project} onClick={() => viewPostDetails(project)}>
       <div>
         <div className={styles.title}>{title} </div>
         <div className={styles.meta}>{creator.name} - {DateTime.fromJSDate(createdAt).toRelative()} </div>
@@ -355,10 +354,11 @@ function Project ({ memberCap, project, routeParams, showDetails }) {
   )
 }
 
-function Event ({ memberCap, event, routeParams, showDetails }) {
-  const { id, location, eventInvitations, startTime, title } = event
+function Event ({ memberCap, event }) {
+  const { location, eventInvitations, startTime, title } = event
+  const viewPostDetails = useViewPostDetails()
   return (
-    <div className={styles.event} onClick={() => showDetails(id, { ...routeParams })}>
+    <div className={styles.event} onClick={() => viewPostDetails(event)}>
       <div className={styles.date}>
         <div className={styles.month}>{DateTime.fromJSDate(startTime).toFormat('MMM')}</div>
         <div className={styles.day}>{DateTime.fromJSDate(startTime).toFormat('dd')}</div>

--- a/apps/web/src/routes/PostDetail/PostDetail.js
+++ b/apps/web/src/routes/PostDetail/PostDetail.js
@@ -54,7 +54,8 @@ function PostDetail () {
   const location = useLocation()
   const routeParams = useParams()
   const postId = routeParams.postId || getQuerystringParam('fromPostId', location)
-  const { groupSlug, commentId, view } = routeParams
+  const { groupSlug, view } = routeParams
+  const commentId = getQuerystringParam('commentId', location) || routeParams.commentId
 
   const currentGroup = useSelector(state => getGroupForSlug(state, groupSlug))
   const postSelector = useSelector(state => getPost(state, postId))
@@ -207,7 +208,7 @@ function PostDetail () {
       <ScrollListener elementId={DETAIL_COLUMN_ID} onScroll={handleScroll} />
       <PostHeader
         className={classes.header}
-        {...post}
+        post={post}
         routeParams={{ groupSlug, postId, commentId, view }}
         close={onClose}
         expanded
@@ -219,7 +220,7 @@ function PostDetail () {
           <PostHeader
             className={classes.header}
             currentUser={currentUser}
-            {...post}
+            post={post}
             routeParams={{ groupSlug, postId, commentId, view }}
             close={onClose}
             isFlagged={isFlagged}

--- a/apps/web/src/store/actions/fetchMyMemberships.js
+++ b/apps/web/src/store/actions/fetchMyMemberships.js
@@ -42,6 +42,9 @@ export default function fetchMyMemberships () {
                       id
                       lastReadPostId
                       newPostCount
+                      settings {
+                        notifications
+                      }
                     }
                   }
                 }

--- a/apps/web/src/util/navigation.js
+++ b/apps/web/src/util/navigation.js
@@ -216,7 +216,7 @@ export function widgetUrl ({ widget, rootPath, groupSlug: providedSlug, context 
   } else if (widget.viewUser) {
     url = personUrl(widget.viewUser.id, groupSlug)
   } else if (widget.viewPost) {
-    url = postUrl(widget.viewPost, { groupSlug, context })
+    url = postUrl(widget.viewPost.id, { groupSlug, context })
   } else if (widget.viewChat) {
     url = chatUrl(widget.viewChat.name, { rootPath, groupSlug, context })
   } else if (widget.customView) {

--- a/apps/web/src/util/navigation.js
+++ b/apps/web/src/util/navigation.js
@@ -125,8 +125,29 @@ export function duplicatePostUrl (id, opts = {}) {
   return createPostUrl(opts, { fromPostId: id })
 }
 
-export function postCommentUrl ({ postId, commentId, ...opts }, querystringParams = {}) {
-  return `${postUrl(postId, opts, querystringParams)}/comments/${commentId}`
+// Given a post return the the main way to view the post
+// Chats go to the chat room scrolled to the post
+// Posts go to the stream with the post opened
+export function primaryPostUrl (post, opts = {}, querystringParams = {}) {
+  let result = baseUrl(opts)
+  const postId = get('id', post) || post
+  if (post.type === 'chat') {
+    // If topicName passed in we are opening the post from a specific chat room, otherwise if a chat then always open its first topic chat room
+    const topicName = post.topics[0].name
+    if (opts.commentId) {
+      // When there is a commentId we pass the postId in the route params so that the post is opened when the room is loaded
+      result = `${result}/chat/${topicName}/post/${postId}?commentId=${opts.commentId}`
+    } else {
+      // When there is no commentId, we pass the postId in the querystring so that the post is highlighted but not opened when the room is loaded
+      result = `${result}/chat/${topicName}?postId=${postId}`
+    }
+  } else {
+    result = `${result}/post/${postId}`
+    if (opts.commentId) {
+      result = `${result}?commentId=${opts.commentId}`
+    }
+  }
+  return addQuerystringToPath(result, querystringParams)
 }
 
 // Messages URLs
@@ -195,7 +216,7 @@ export function widgetUrl ({ widget, rootPath, groupSlug: providedSlug, context 
   } else if (widget.viewUser) {
     url = personUrl(widget.viewUser.id, groupSlug)
   } else if (widget.viewPost) {
-    url = postUrl(widget.viewPost.id, { groupSlug, context })
+    url = postUrl(widget.viewPost, { groupSlug, context })
   } else if (widget.viewChat) {
     url = chatUrl(widget.viewChat.name, { rootPath, groupSlug, context })
   } else if (widget.customView) {

--- a/apps/web/src/util/navigation.test.js
+++ b/apps/web/src/util/navigation.test.js
@@ -7,7 +7,7 @@ import {
   setQuerystringParam,
   removeGroupFromUrl,
   createUrl,
-  postCommentUrl,
+  primaryPostUrl,
   messagePersonUrl,
   isPublicPath,
   isMapView,
@@ -158,10 +158,10 @@ describe('createUrl', () => {
   })
 })
 
-describe('postCommentUrl', () => {
+describe('primaryPostUrl with comment', () => {
   it('returns correct path', () => {
     const expected = '/all/post/123/comments/456'
-    const actual = postCommentUrl({ postId: '123', commentId: '456' })
+    const actual = primaryPostUrl('123', { commentId: '456' })
     expect(actual).toEqual(expected)
   })
 })


### PR DESCRIPTION
Ensure notifications for chat posts go to the chat room, and others go directly to the post.

Clean up how we link to posts on the front-end creating new useViewPostDetails hook.

Switch from adding comments/:commentId to jump to a specific omment to ?commentId=XXX