### PR TITLE
fix bug: question marks in proposal options

### DIFF
--- a/apps/backend/api/models/Post.js
+++ b/apps/backend/api/models/Post.js
@@ -419,11 +419,7 @@ module.exports = bookshelf.Model.extend(Object.assign({
 
     // Execute the insert query for options passed in
     if (options.length > 0) {
-      const insertQuery = `
-        INSERT INTO proposal_options (post_id, text, color, emoji)
-        VALUES ${options.map(option => `(${this.id}, '${option.text}', '${option.color}', '${option.emoji}')`).join(', ')};
-      `
-      await bookshelf.knex.raw(insertQuery).transacting(opts.transacting)
+      await bookshelf.knex('proposal_options').insert(options).transacting(opts.transacting)
     }
 
     // Return a resolved promise


### PR DESCRIPTION
closes #345 

Due to SQL injection protection, "?" was replaced with "$n", where n was a sequential number.

I recommend we audit the code to find all instances of where we may be allowing SQL injection.