### PR TITLE
chore(web,mobile): Fixes HyloEditorMobile but probably breaks it for Web

### DIFF
--- a/apps/web/src/components/HyloEditor/HyloEditor.js
+++ b/apps/web/src/components/HyloEditor/HyloEditor.js
@@ -29,8 +29,6 @@ const HyloEditor = React.forwardRef(({
   onEnter,
   onAltEnter,
   onEscape,
-  onFocus,
-  onBlur,
   placeholder,
   readOnly,
   showMenu = false,
@@ -149,23 +147,12 @@ const HyloEditor = React.forwardRef(({
           content: editor?.getHTML()
         })
       }
-      if (onCreate) onCreate(editor)
+      if (onCreate) onCreate({ editor })
     },
     onUpdate: ({ editor }) => {
       // Don't call onUpdate until the editor is full initialized (including initial content added)
-      if (!onUpdate || !editor || !initialized) return
-      onUpdate(editor.getHTML(), editor.getText())
-    },
-    onFocus: ({ editor }) => {
-      if (editor && onFocus) onFocus()
-    },
-    onBlur: ({ editor }) => {
-      if (editor && onBlur) onBlur()
-    },
-    editorProps: {
-      attributes: {
-        class: 'prose prose-sm sm:prose lg:prose-lg xl:prose-2xl focus:outline-none'
-      }
+      if (!onUpdate || !initialized) return
+      onUpdate(editor.getHTML())
     }
   })
 
@@ -175,7 +162,7 @@ const HyloEditor = React.forwardRef(({
       editor.commands.setContent(contentHTML)
       setInitialized(true)
     }
-  }, [editor, editor.isInitialized])
+  }, [editor?.isInitialized, contentHTML])
 
   // Dynamic placeholder text
   useEffect(() => {


### PR DESCRIPTION
Changing `onCreate(editor)` to `onCreate({ editor })` gets the content loading again, but changes don’t save without also removing the `onFocus`, `onBlur`, and initialized stuff. Also, this change of signature for `onCreate` may reflect a change made in Web code, so something may need to be updated in Web to go back to this function signature? These callback methods I’ve tried to keep with the same signature of the underlying useEditor/TipTap callbacks for simplicity. Don’t want to commit this as it is gonna break something in Web I’m sure, but here this branch/PR does work on Mobile for reference, and maybe we can work back from here?