### PR TITLE
Context switching links, Improved UX, openURL updates, etc

### DIFF
--- a/apps/mobile/src/components/ContextMenu/ContextMenu.js
+++ b/apps/mobile/src/components/ContextMenu/ContextMenu.js
@@ -9,7 +9,7 @@ import useContextWidgetChildren from '@hylo/hooks/useContextWidgetChildren'
 import useHasResponsibility, { RESP_ADD_MEMBERS, RESP_ADMINISTRATION } from '@hylo/hooks/useHasResponsibility'
 import { widgetUrl as makeWidgetUrl, groupUrl } from 'util/navigation'
 import useLogout from 'hooks/useLogout'
-import { openURL } from 'hooks/useOpenURL'
+import useOpenURL from 'hooks/useOpenURL'
 import useRouteParams from 'hooks/useRouteParams'
 import GroupMenuHeader from 'components/GroupMenuHeader'
 import WidgetIconResolver from 'components/WidgetIconResolver'
@@ -18,6 +18,7 @@ export default function ContextMenu () {
   const insets = useSafeAreaInsets()
   const navigation = useNavigation()
   const { t } = useTranslation()
+  const openURL = useOpenURL()
   const [{ currentGroup, fetching }] = useCurrentGroup()
   const widgets = useMemo(() =>
     orderContextWidgetsForContextMenu(currentGroup?.contextWidgets || []),
@@ -25,7 +26,7 @@ export default function ContextMenu () {
 
   useEffect(() => {
     if ((!fetching && currentGroup?.shouldWelcome)) {
-      navigation.navigate('Group Welcome')
+      navigation.replace('Group Welcome')
     }
   }, [fetching, currentGroup])
 
@@ -37,7 +38,8 @@ export default function ContextMenu () {
       },
       rootPath: `/groups/${currentGroup?.slug}`,
       groupSlug: currentGroup?.slug
-    })
+    }),
+    { replace: true }
   )
 
   if (!currentGroup) return null
@@ -75,6 +77,7 @@ export default function ContextMenu () {
 function MenuItem ({ widget, groupSlug, rootPath, group }) {
   const { t } = useTranslation()
   const { listItems, loading } = useContextWidgetChildren({ widget, groupSlug })
+  const openURL = useOpenURL()
   const logout = useLogout()
   const hasResponsibility = useHasResponsibility({ forCurrentGroup: true, forCurrentUser: true })
   const canAdmin = hasResponsibility(RESP_ADMINISTRATION)
@@ -93,7 +96,7 @@ function MenuItem ({ widget, groupSlug, rootPath, group }) {
 
   const handleWidgetPress = widget => {
     const linkingPath = makeWidgetUrl({ widget, rootPath, groupSlug: currentGroup?.slug })
-    openURL(linkingPath)
+    openURL(linkingPath, { replace: true })
   }
 
   if (isHiddenInContextMenuResolver(widget)) return null
@@ -182,13 +185,14 @@ function ChildWidget ({ widget, handleWidgetPress, rootPath, groupSlug, parentUr
 function TopElements ({ widget, group }) {
   const { t } = useTranslation()
   const navigation = useNavigation()
+  const openURL = useOpenURL()
   const hasResponsibility = useHasResponsibility({ forCurrentGroup: true, forCurrentUser: true })
   const canAddMembers = hasResponsibility(RESP_ADD_MEMBERS)
 
   if (widget.type === 'members' && canAddMembers) {
     return (
       <TouchableOpacity
-        onPress={() => navigation.navigate('Group Settings', { groupSlug: group?.slug, screen: 'invite' })}
+        onPress={() => navigation.replace('Group Settings', { groupSlug: group?.slug, screen: 'invite' })}
         className='px-4 py-2 bg-primary rounded-md'
       >
         <Text className='text-sm font-medium text-white'>{t('Add Members')}</Text>
@@ -209,7 +213,7 @@ function TopElements ({ widget, group }) {
     const settingsUrl = groupUrl(group.slug, 'settings') + '/details'
     const ListItem = ({ title, url }) => (
       <TouchableOpacity
-        onPress={() => openURL(url)}
+        onPress={() => openURL(url, { replace: true })}
         className='w-full'
       >
         <View className='w-full border-2 border-foreground/20 rounded-md p-2 mb-2 bg-background'>
@@ -221,7 +225,7 @@ function TopElements ({ widget, group }) {
     return (
       <View className='w-full mb-2'>
         <TouchableOpacity
-          onPress={() => navigation.navigate('Group Settings', { groupSlug: group?.slug })}
+          onPress={() => navigation.replace('Group Settings', { groupSlug: group?.slug })}
           className='w-full'
         >
           <View className='w-full border-2 border-foreground/20 rounded-md p-2 mb-2 bg-background'>

--- a/apps/mobile/src/components/ContextSwitchMenu/ContextSwitchMenu.js
+++ b/apps/mobile/src/components/ContextSwitchMenu/ContextSwitchMenu.js
@@ -9,7 +9,7 @@ import { clsx } from 'clsx'
 import useCurrentUser from '@hylo/hooks/useCurrentUser'
 import useCurrentGroup, { useContextGroups } from '@hylo/hooks/useCurrentGroup'
 import { widgetUrl as makeWidgetUrl } from 'util/navigation'
-import { openURL } from 'hooks/useOpenURL'
+import useOpenURL from 'hooks/useOpenURL'
 import useChangeToGroup from 'hooks/useChangeToGroup'
 import { black, white } from 'style/colors'
 
@@ -17,6 +17,7 @@ const STAY_EXPANDED_DURATION = 1500
 
 export default function ContextSwitchMenu ({ isExpanded, setIsExpanded }) {
   const insets = useSafeAreaInsets()
+  const openURL = useOpenURL()
   const changeToGroup = useChangeToGroup()
   const [{ currentUser }] = useCurrentUser()
   const [{ currentGroup }] = useCurrentGroup()
@@ -52,7 +53,7 @@ export default function ContextSwitchMenu ({ isExpanded, setIsExpanded }) {
       widget: context?.homeWidget,
       groupSlug: context?.slug
     })
-    if (homePath) openURL(homePath)
+    if (homePath) openURL(homePath, { replace: true })
   }
 
   return (

--- a/apps/mobile/src/components/ContextSwitchMenu/ContextSwitchMenu.js
+++ b/apps/mobile/src/components/ContextSwitchMenu/ContextSwitchMenu.js
@@ -29,7 +29,6 @@ export default function ContextSwitchMenu ({ isExpanded, setIsExpanded }) {
   const collapseTimeout = useRef(null)
 
   const startCollapseTimer = () => {
-    console.log('startCollapseTimer')
     clearTimeout(collapseTimeout.current)
     collapseTimeout.current = setTimeout(() => {
       setIsExpanded(false)

--- a/apps/mobile/src/navigation/AuthRootNavigator.js
+++ b/apps/mobile/src/navigation/AuthRootNavigator.js
@@ -153,32 +153,31 @@ export default function AuthRootNavigator () {
     <HyloHTMLConfigProvider>
       <AuthRoot.Navigator {...navigatorProps}>
         <AuthRoot.Screen name='Drawer' component={DrawerNavigator} options={{ headerShown: false }} />
-        <AuthRoot.Screen
-          name='Create Group' component={CreateGroupTabsNavigator}
-          options={{ headerShown: false }}
-        />
+        <AuthRoot.Screen name='Create Group' component={CreateGroupTabsNavigator} options={{ headerShown: false }} />
+        <AuthRoot.Screen name='Loading' component={LoadingScreen} options={{ headerShown: false, animationEnabled: false }} />
+        {/*
+          == Modals ==
+          modelScreenName is used to differentiated screen names from ones that have a non-model counterpart
+          and simply appends '- Modal`
+        */}
         <AuthRoot.Group screenOptions={{ presentation: 'modal', header: ModalHeader }}>
           <AuthRoot.Screen
-            name={modalScreenName('Post Details')} component={PostDetails}
-            options={{ title: 'Post Details' }}
-          />
-          <AuthRoot.Screen
-            name={modalScreenName('Creation')} component={CreationOptions}
-            options={{ title: 'Create' }}
-          />
-          <AuthRoot.Screen
-            name={modalScreenName('Member')} component={MemberProfile}
-            options={{ title: 'Member' }}
-          />
-          <AuthRoot.Screen
-            name={modalScreenName('Group Explore')} component={GroupExploreWebView}
-            options={{ title: 'Explore' }}
+            name='Creation'
+            component={CreationOptions}
+            options={{
+              title: 'Create',
+              presentation: 'transparentModal',
+              headerShown: false,
+              cardStyle: { backgroundColor: 'transparent' }
+            }}
           />
           <AuthRoot.Screen name='Edit Post' component={PostEditor} options={{ headerShown: false }} />
+          <AuthRoot.Screen name={modalScreenName('Group Explore')} component={GroupExploreWebView} options={{ title: 'Explore' }} />
+          <AuthRoot.Screen name={modalScreenName('Member')} component={MemberProfile} options={{ title: 'Member' }} />
+          <AuthRoot.Screen name='Notifications' component={NotificationsList} />
+          <AuthRoot.Screen name={modalScreenName('Post Details')} component={PostDetails} options={{ title: 'Post Details' }} />
           <AuthRoot.Screen name={modalScreenName('Thread')} component={Thread} />
-          <AuthRoot.Screen name={modalScreenName('Notifications')} component={NotificationsList} />
         </AuthRoot.Group>
-        <AuthRoot.Screen name='Loading' component={LoadingScreen} options={{ headerShown: false, animationEnabled: false }} />
       </AuthRoot.Navigator>
     </HyloHTMLConfigProvider>
   )

--- a/apps/mobile/src/navigation/HomeNavigator.js
+++ b/apps/mobile/src/navigation/HomeNavigator.js
@@ -1,6 +1,8 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { createStackNavigator } from '@react-navigation/stack'
-import useCurrentGroup from '@hylo/hooks/useCurrentGroup'
+import useCurrentGroup, { useContextGroups } from '@hylo/hooks/useCurrentGroup'
+import useRouteParams from 'hooks/useRouteParams'
+import useChangeToGroup from 'hooks/useChangeToGroup'
 import useOpenInitialURL from 'hooks/useOpenInitialURL'
 import useReturnToOnAuthPath from 'hooks/useReturnToOnAuthPath'
 // Helper Components
@@ -25,8 +27,42 @@ import MapWebView from 'screens/MapWebView/MapWebView'
 const HomeTab = createStackNavigator()
 export default function HomeNavigator ({ navigation }) {
   const [{ currentGroup }] = useCurrentGroup()
+  const changeToGroup = useChangeToGroup()
+  const { myContext, publicContext } = useContextGroups()
+  const { context, groupSlug } = useRouteParams()
+
+  // The following 3 steps are the final steps in linking within the app:
+
+  // === initialURL ===
+  // If the app was launched via navigation to a URL this hook retrieves
+  // that path and navigates to it. The value is cleared is then cleared
+  // from memory but kept here temporarily to use as a flag to disable
+  // initial animations to make navigation to the destination to make it
+  // happen more seamlessly.
   const initialURL = useOpenInitialURL()
+
+  // === returnToOnAuth ===
+  // When the app is launched or brought into focus via navigation to
+  // a path which requires auth, and the user is not authorized, that
+  // path is stored for later use in a zustand global store and then
+  // navigated to here if it existed (as we're always auth'd), and
+  // then cleared from memory.
   useReturnToOnAuthPath()
+
+  // === context and groupSlug ===
+  // The context and groupSlug are retrieved from the screens params
+  // added by any link that has those named params. They are used here
+  // to switch to the home tab to that context/group while the remaining
+  // route params from the matched link are handled in the final
+  // component in the screen path (e.g. id for a post/:id path is retrieved
+  // in the PostDetails component).
+  useEffect(() => {
+    if (context === 'groups' && groupSlug) {
+      changeToGroup(groupSlug, false)
+    } else if ([myContext.slug, publicContext.slug].includes(context)) {
+      changeToGroup(context, false)
+    }
+  }, [context, groupSlug])
 
   const navigatorProps = {
     screenOptions: {

--- a/apps/mobile/src/navigation/HomeNavigator.js
+++ b/apps/mobile/src/navigation/HomeNavigator.js
@@ -35,27 +35,25 @@ export default function HomeNavigator ({ navigation }) {
 
   // === initialURL ===
   // If the app was launched via navigation to a URL this hook retrieves
-  // that path and navigates to it. The value is cleared is then cleared
-  // from memory but kept here temporarily to use as a flag to disable
-  // initial animations to make navigation to the destination to make it
-  // happen more seamlessly.
+  // that path and navigates to it. The value is then cleared from memory,
+  // but kept here temporarily to use as a flag to disable initial animations
+  // for a more seamless initial loading experience.
   const initialURL = useOpenInitialURL()
 
   // === returnToOnAuth ===
   // When the app is launched or brought into focus via navigation to
   // a path which requires auth, and the user is not authorized, that
   // path is stored for later use in a zustand global store and then
-  // navigated to here if it existed (as we're always auth'd), and
-  // then cleared from memory.
+  // navigated to here now that we're auth'd. The memory is then cleared.
+  // Generally good UX, but especially important for handling of JoinGroup.
   useReturnToOnAuthPath()
 
-  // === context and groupSlug ===
-  // The context and groupSlug are retrieved from the screens params
-  // added by any link that has those named params. They are used here
-  // to switch to the home tab to that context/group while the remaining
-  // route params from the matched link are handled in the final
-  // component in the screen path (e.g. id for a post/:id path is retrieved
-  // in the PostDetails component).
+  // === :context and :groupSlug path match handling ===
+  // The context and groupSlug are retrieved from the screen params added by
+  // any link that has those named params. They are used here to set that
+  // context/group as current. The remaining route params from the matched link
+  // are handled in the final component in the screen path (e.g. id for a
+  // post/:id path match is retrieved in the PostDetails component).
   useEffect(() => {
     if (context === 'groups' && groupSlug) {
       changeToGroup(groupSlug, false)

--- a/apps/mobile/src/navigation/TabsNavigator.js
+++ b/apps/mobile/src/navigation/TabsNavigator.js
@@ -4,7 +4,6 @@ import { useNavigation } from '@react-navigation/native'
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs'
 import { isIOS } from 'util/platform'
 import useCurrentUser from '@hylo/hooks/useCurrentUser'
-import { modalScreenName } from 'hooks/useIsModalScreen'
 import HomeNavigator from 'navigation/HomeNavigator'
 import Icon from 'components/Icon'
 import MessagesNavigator from 'navigation/MessagesNavigator'
@@ -64,7 +63,7 @@ export default function TabsNavigator () {
         component={DummyComponent}
         listeners={{
           tabPress: (e) => {
-            navigation.navigate(modalScreenName('Notifications'))
+            navigation.navigate('Notifications')
             e.preventDefault()
           }
         }}

--- a/apps/mobile/src/navigation/headers/TabStackHeader.js
+++ b/apps/mobile/src/navigation/headers/TabStackHeader.js
@@ -24,7 +24,10 @@ export default function TabStackHeader ({
 
   const props = {
     headerBackTitleVisible: false,
-    title: getFocusedRouteNameFromRoute(route) || getHeaderTitle(options, route.name),
+    // NOTE: The previous default TabStackheader was as follows, which is likely near the
+    // the React Navigation default:
+    // getFocusedRouteNameFromRoute(route) || getHeaderTitle(options, route.name),
+    title: currentGroup?.name,
     headerTitle: options.headerTitle,
     headerTitleContainerStyle: {
       // Follow: https://github.com/react-navigation/react-navigation/issues/7057#issuecomment-593086348
@@ -47,7 +50,7 @@ export default function TabStackHeader ({
           ? navigation.goBack
           : navigation.openDrawer
       }
-
+console.log()
       return (
         <>
           <FocusAwareStatusBar />
@@ -56,7 +59,7 @@ export default function TabStackHeader ({
             labelVisible={false}
             backImage={() => (
               <View style={styles.container}>
-                <ChevronLeft style={styles.backIcon} size={32} />
+                <ChevronLeft style={styles.backIcon} />
                 <FastImage source={{ uri: avatarUrl }} style={styles.avatar} />
               </View>
             )}

--- a/apps/mobile/src/navigation/headers/TabStackHeader.js
+++ b/apps/mobile/src/navigation/headers/TabStackHeader.js
@@ -1,16 +1,15 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { StyleSheet, View } from 'react-native'
 import FastImage from 'react-native-fast-image'
-import { getFocusedRouteNameFromRoute } from '@react-navigation/native'
+import { getFocusedRouteNameFromRoute, useNavigation } from '@react-navigation/native'
 import { Header, HeaderBackButton, getHeaderTitle } from '@react-navigation/elements'
 import { ChevronLeft } from 'lucide-react-native'
 import useCurrentGroup from '@hylo/hooks/useCurrentGroup'
 import { isIOS } from 'util/platform'
 import FocusAwareStatusBar from 'components/FocusAwareStatusBar'
-import { white } from 'style/colors'
+import { black, white } from 'style/colors'
 
 export default function TabStackHeader ({
-  navigation,
   route,
   options,
   back,
@@ -18,6 +17,7 @@ export default function TabStackHeader ({
   headerRight,
   ...otherProps
 }) {
+  const navigation = useNavigation()
   const [{ currentGroup }] = useCurrentGroup()
   const avatarUrl = currentGroup?.headerAvatarUrl ||
     currentGroup?.avatarUrl
@@ -50,17 +50,17 @@ export default function TabStackHeader ({
           ? navigation.goBack
           : navigation.openDrawer
       }
-console.log()
+
       return (
         <>
           <FocusAwareStatusBar />
           <HeaderBackButton
             onPress={onPress}
             labelVisible={false}
-            backImage={() => (
+            backImage={({ tintColor }) => (
               <View style={styles.container}>
-                <ChevronLeft style={styles.backIcon} />
-                <FastImage source={{ uri: avatarUrl }} style={styles.avatar} />
+                <ChevronLeft style={styles.backIcon} color={tintColor} size={30} />
+                <FastImage style={styles.avatar} source={{ uri: avatarUrl }} />
               </View>
             )}
           />

--- a/apps/mobile/src/navigation/headers/TabStackHeader.js
+++ b/apps/mobile/src/navigation/headers/TabStackHeader.js
@@ -29,7 +29,7 @@ export default function TabStackHeader ({
     headerTitleContainerStyle: {
       // Follow: https://github.com/react-navigation/react-navigation/issues/7057#issuecomment-593086348
       alignItems: 'left',
-      marginLeft: isIOS ? 10 : 10
+      marginLeft: isIOS ? 10 : 20
     },
     headerTitleStyle: {
       fontFamily: 'Circular-Bold',

--- a/apps/mobile/src/navigation/linking/index.js
+++ b/apps/mobile/src/navigation/linking/index.js
@@ -59,7 +59,8 @@ export const routingConfig = {
   // This route isn't correct; no such screen exists. And its not to be confused with the Group Explore screen.
   '/:context(public)/groups':                                             `${AUTH_ROOT_SCREEN_NAME}/Drawer/Tabs/Home Tab/Group Explorer`,
   '/:context(public)/map':                                                `${AUTH_ROOT_SCREEN_NAME}/Drawer/Tabs/Home Tab/Map`,
-  '/:context(public)/:groupSlug/post/:postId':                            `${AUTH_ROOT_SCREEN_NAME}/Drawer/Tabs/Home Tab/Post Detail`,
+  // TODO: Is this a valid route? / Ever used?
+  '/:context(public)/:groupSlug/post/:id':                                `${AUTH_ROOT_SCREEN_NAME}/Drawer/Tabs/Home Tab/Post Details`,
   '/:context(public)/topics/:topicName':                                  `${AUTH_ROOT_SCREEN_NAME}/Drawer/Tabs/Home Tab/Stream`,
   '/:context(public)/stream':                                             `${AUTH_ROOT_SCREEN_NAME}/Drawer/Tabs/Home Tab/Stream`,
   '/:context(public)/:streamType(discussions)':                           `${AUTH_ROOT_SCREEN_NAME}/Drawer/Tabs/Home Tab/Stream`,
@@ -112,11 +113,11 @@ export const routingConfig = {
   // /groups Routes
   '/:context(groups)/:groupSlug/about':                                   `${AUTH_ROOT_SCREEN_NAME}/Drawer/Tabs/Home Tab/Group Detail`,
   '/:context(groups)/:groupSlug/all-views':                               `${AUTH_ROOT_SCREEN_NAME}/Drawer/Tabs/Home Tab/All Views`,
-  '/:context(groups)/:groupSlug/post/:postId':                            `${AUTH_ROOT_SCREEN_NAME}/Drawer/Tabs/Home Tab/Post Detail`,
+  '/:context(groups)/:groupSlug/post/:id':                                `${AUTH_ROOT_SCREEN_NAME}/Drawer/Tabs/Home Tab/Post Details`,
   '/:context(groups)/:groupSlug/post/:id/edit':                           `${AUTH_ROOT_SCREEN_NAME}/Edit Post`,
   '/:context(groups)/:groupSlug/chat/:topicName':                         `${AUTH_ROOT_SCREEN_NAME}/Drawer/Tabs/Home Tab/Chat Room`,
   // TODO: Routing - should probably go to Post Modal for now, or let it through and it will go to PostDetail in Webview, same for topics variant below
-  '/:context(groups)/:groupSlug/chat/:topicName/post/:postId':            `${AUTH_ROOT_SCREEN_NAME}/Drawer/Tabs/Home Tab/Chat Room`,
+  '/:context(groups)/:groupSlug/chat/:topicName/post/:id':                `${AUTH_ROOT_SCREEN_NAME}/Drawer/Tabs/Home Tab/Chat Room`,
   '/:context(groups)/:groupSlug/create':                                  `${AUTH_ROOT_SCREEN_NAME}/Edit Post`,
   '/:context(groups)/:groupSlug/explore':                                 `${AUTH_ROOT_SCREEN_NAME}/Drawer/Tabs/Home Tab/Group Explore`,
   '/:context(groups)/:groupSlug/groups':                                  `${AUTH_ROOT_SCREEN_NAME}/Drawer/Tabs/Home Tab/Group Relationships`,
@@ -126,7 +127,7 @@ export const routingConfig = {
   '/:context(groups)/:groupSlug/members/:id':                             `${AUTH_ROOT_SCREEN_NAME}/Drawer/Tabs/Home Tab/Member`,
   // TODO: Routing -- Actually legacy redirection, consider creating or adding to a redirect mapper
   '/:context(groups)/:groupSlug/topics/:topicName':                       `${AUTH_ROOT_SCREEN_NAME}/Drawer/Tabs/Home Tab/Chat Room`,
-  '/:context(groups)/:groupSlug/topics/:topicName/post/:postId'         : `${AUTH_ROOT_SCREEN_NAME}/Drawer/Tabs/Home Tab/Chat Room`,
+  '/:context(groups)/:groupSlug/topics/:topicName/post/:id':              `${AUTH_ROOT_SCREEN_NAME}/Drawer/Tabs/Home Tab/Chat Room`,
   '/:context(groups)/:groupSlug/custom/:customViewId':                    `${AUTH_ROOT_SCREEN_NAME}/Drawer/Tabs/Home Tab/Stream`,
   '/:context(groups)/:groupSlug/settings/:settingsArea':                  `${AUTH_ROOT_SCREEN_NAME}/Drawer/Tabs/Home Tab/Group Settings`,
   '/:context(groups)/:groupSlug/settings':                                `${AUTH_ROOT_SCREEN_NAME}/Drawer/Tabs/Home Tab/Group Settings`,
@@ -147,7 +148,7 @@ export const routingConfig = {
   '/messages':                                                            `${AUTH_ROOT_SCREEN_NAME}/Drawer/Tabs/Messages Tab/Messages`,
 
   // Miscellaneous Routes
-  '/notifications':                                                       `${AUTH_ROOT_SCREEN_NAME}/${modalScreenName('Notifications')}`,
+  '/notifications':                                                       `${AUTH_ROOT_SCREEN_NAME}/Notifications`,
   '/search':                                                              `${AUTH_ROOT_SCREEN_NAME}/Drawer/Tabs/Search Tab`,
 
   // Catch-Alls and Safeties
@@ -159,7 +160,7 @@ export const routingConfig = {
   ':unmatchedBasePath(.*)/post/:id/comments/:commentId':                  `${AUTH_ROOT_SCREEN_NAME}/${modalScreenName('Post Details')}`,
   ':unmatchedBasePath(.*)/create/group':                                  `${AUTH_ROOT_SCREEN_NAME}/Create Group`,
   ':unmatchedBasePath(.*)/create/post':                                   `${AUTH_ROOT_SCREEN_NAME}/Edit Post`,
-  ':unmatchedBasePath(.*)/create':                                        `${AUTH_ROOT_SCREEN_NAME}/${modalScreenName('Creation')}`,
+  ':unmatchedBasePath(.*)/create':                                        `${AUTH_ROOT_SCREEN_NAME}/Creation`,
   ':unmatchedBasePath(.*)/post/:id/edit':                                 `${AUTH_ROOT_SCREEN_NAME}/Edit Post`,
   ...unknownRouteMatch
 }

--- a/apps/mobile/src/screens/CreationOptions/CreationOptions.js
+++ b/apps/mobile/src/screens/CreationOptions/CreationOptions.js
@@ -1,53 +1,60 @@
 import React from 'react'
-import { View, Text, TouchableOpacity } from 'react-native'
+import { View, Text, TouchableOpacity, TouchableWithoutFeedback } from 'react-native'
 import { useTranslation } from 'react-i18next'
+import { useNavigation } from '@react-navigation/native'
 import { PenSquare, Users } from 'lucide-react-native'
-import { openURL } from 'hooks/useOpenURL'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 export default function CreationOptions () {
   const { t } = useTranslation()
-  const handleCreatePost = () => {
-    openURL('/create/post')
-  }
-  const handleCreateGroup = () => {
-    openURL('/create/group')
-  }
+  const insets = useSafeAreaInsets()
+  const navigation = useNavigation()
 
   return (
-    <View className='flex-1 justify-center bg-background p-4 gap-4'>
-      <TouchableOpacity
-        onPress={handleCreatePost}
-        className='bg-card rounded-lg p-6 border-2 border-foreground/20'
+    <TouchableWithoutFeedback onPress={() => navigation.goBack()}>
+      <View
+        className='flex-1 background-opacity-0.3 justify-end'
+        style={{ backgroundColor: 'rgba(0, 0, 0, 0.3)' }}
       >
-        <View className='flex-row items-center gap-3'>
-          <PenSquare size={24} className='text-foreground' />
-          <View>
-            <Text className='text-lg font-bold text-foreground'>
-              {t('Create Post')}
-            </Text>
-            <Text className='text-sm text-foreground/60'>
-              {t('Share updates, events, offers, or requests')}
-            </Text>
-          </View>
-        </View>
-      </TouchableOpacity>
+        <View
+          className='bg-background'
+          style={{ paddingBottom: insets.bottom + 40, borderTopLeftRadius: 20, borderTopRightRadius: 20 }}
+        >
+          <TouchableOpacity
+            onPress={() => navigation.replace('Edit Post')}
+            className='bg-card rounded-lg p-3 m-5 mb-0 border-2 border-foreground/20'
+          >
+            <View className='flex-row items-center gap-3'>
+              <PenSquare size={24} className='text-foreground' />
+              <View>
+                <Text className='text-lg font-bold text-foreground'>
+                  {t('Create Post')}
+                </Text>
+                <Text className='text-sm text-foreground/60'>
+                  {t('Share updates, events, offers, or requests')}
+                </Text>
+              </View>
+            </View>
+          </TouchableOpacity>
 
-      <TouchableOpacity
-        onPress={handleCreateGroup}
-        className='bg-card rounded-lg p-6 border-2 border-foreground/20'
-      >
-        <View className='flex-row items-center gap-3'>
-          <Users size={24} className='text-foreground' />
-          <View>
-            <Text className='text-lg font-bold text-foreground'>
-              {t('Create Group')}
-            </Text>
-            <Text className='text-sm text-foreground/60'>
-              {t('Start a new community or project')}
-            </Text>
-          </View>
+          <TouchableOpacity
+            onPress={() => navigation.replace('Create Group')}
+            className='bg-card rounded-lg p-3 m-5 border-2 border-foreground/20'
+          >
+            <View className='flex-row items-center gap-3'>
+              <Users size={24} className='text-foreground' />
+              <View>
+                <Text className='text-lg font-bold text-foreground'>
+                  {t('Create Group')}
+                </Text>
+                <Text className='text-sm text-foreground/60'>
+                  {t('Start a new community or project')}
+                </Text>
+              </View>
+            </View>
+          </TouchableOpacity>
         </View>
-      </TouchableOpacity>
-    </View>
+      </View>
+    </TouchableWithoutFeedback>
   )
 }

--- a/apps/mobile/src/screens/JoinGroup/JoinGroup.js
+++ b/apps/mobile/src/screens/JoinGroup/JoinGroup.js
@@ -55,9 +55,9 @@ export default function JoinGroup (props) {
             } else {
               if (isValidInvite) {
                 setReturnToOnAuthPath(originalLinkingPath)
-                openURL('/signup?message=Signup or login to join this group.', true)
+                openURL('/signup?message=Signup or login to join this group.', { reset: true })
               } else {
-                openURL('/signup?error=invite-expired', true)
+                openURL('/signup?error=invite-expired', { reset: true })
               }
             }
           } catch (error) {

--- a/apps/mobile/src/screens/LoginByTokenHandler/LoginByTokenHandler.js
+++ b/apps/mobile/src/screens/LoginByTokenHandler/LoginByTokenHandler.js
@@ -49,7 +49,7 @@ export default function LoginByTokenHandler () {
     if (navigationRef.canGoBack()) {
       navigationRef.dispatch(StackActions.pop())
     } else if (isAuthorized) {
-      openURL('/', true)
+      openURL('/', { reset: true })
     }
   }, [isAuthorized])
 

--- a/apps/mobile/src/screens/MapWebView/MapWebView.js
+++ b/apps/mobile/src/screens/MapWebView/MapWebView.js
@@ -32,7 +32,7 @@ export default function MapWebView ({ navigation }) {
       title: screenTitle(group),
       // Disables going back by pull right on this screen
       gestureEnabled: false,
-      headerLeftOnPress: canGoBack ? webViewRef.current.goBack : navigation.goBack
+      headerLeftOnPress: canGoBack ? webViewRef.current.goBack : undefined
     })
 
     // Disables swipeEnabled on DrawerNavigator

--- a/apps/mobile/src/screens/Stream/Stream.js
+++ b/apps/mobile/src/screens/Stream/Stream.js
@@ -119,6 +119,10 @@ export default function Stream () {
   const [, updateUserSettings] = useMutation(updateUserSettingsMutation)
   const [, resetGroupNewPostCount] = useMutation(resetGroupNewPostCountMutation)
 
+  useEffect(() => {
+    navigation.setOptions({ title: currentGroup?.name })
+  }, [currentGroup?.name])
+
   const title = useMemo(() => {
     if (myHome) {
       return capitalize(t(myHome))
@@ -137,12 +141,8 @@ export default function Stream () {
       return capitalize(t(streamType))
     }
 
-    return currentGroup?.name
+    return t('Stream')
   }, [navigation, currentGroup?.id, myHome, streamType, context])
-
-  useEffect(() => {
-    navigation.setOptions({ title })
-  }, [title])
 
   // TODO: URQL - Can this be simplified? Also, does this perhaps follow the same logic as
   // group(updateLastViewed: true) and could we combine this? Currently that extra
@@ -230,13 +230,12 @@ export default function Stream () {
             <StreamHeader
               image={currentGroup.bannerUrl ? { uri: currentGroup.bannerUrl } : null}
               icon={customView?.icon}
-              name={customView?.name || myHome || currentGroup.name}
+              name={title}
               currentGroup={currentGroup}
-              streamType={streamType}
+              streamType={streamQueryVariables.filter}
               customView={customView}
               postPrompt
             />
-
             {!streamType && (
               <View className='bg-card flex-row justify-between items-center px-2.5 py-2'>
                 <ListControl selected={sortBy} onChange={setSortBy} options={sortOptions} />

--- a/apps/mobile/src/screens/Stream/StreamHeader.js
+++ b/apps/mobile/src/screens/Stream/StreamHeader.js
@@ -1,22 +1,19 @@
 import React from 'react'
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native'
-import { useTranslation } from 'react-i18next'
 import { useNavigation } from '@react-navigation/native'
 import FastImage from 'react-native-fast-image'
 import LinearGradient from 'react-native-linear-gradient'
 import useCurrentUser from '@hylo/hooks/useCurrentUser'
-import { firstName as getFirstName } from '@hylo/presenters/PersonPresenter'
-import { isIOS } from 'util/platform'
-import Avatar from 'components/Avatar'
 import Icon from 'components/Icon'
-import { bannerlinearGradientColors, capeCod40, capeCod10, white } from 'style/colors'
+import { bannerlinearGradientColors, white, rhino, black } from 'style/colors'
+import { Plus } from 'lucide-react-native'
 
 export default function StreamHeader ({ image, icon, name, postPrompt = false, currentGroup, streamType }) {
   return (
-    <View style={[styles.bannerContainer, postPrompt && styles.bannerContainerWithPostPrompt]}>
+    <View style={styles.headerContainer}>
       <FastImage source={image} style={styles.image} />
       <LinearGradient style={styles.gradient} colors={bannerlinearGradientColors} />
-      <View style={styles.titleRow}>
+      <View style={styles.header}>
         <View style={styles.title}>
           {icon && (
             <View style={styles.customViewIconContainer}>
@@ -25,15 +22,16 @@ export default function StreamHeader ({ image, icon, name, postPrompt = false, c
           )}
           <Text style={styles.name} numberOfLines={3}>{name}</Text>
         </View>
+        {postPrompt && (
+          <PostPrompt forGroup={currentGroup} currentType={streamType} />
+        )}
       </View>
-      {postPrompt && <PostPrompt forGroup={currentGroup} currentType={streamType} />}
     </View>
   )
 }
 
 export function PostPrompt ({ forGroup, currentType, currentTopicName }) {
   const navigation = useNavigation()
-  const { t } = useTranslation()
   const [{ currentUser }] = useCurrentUser()
 
   if (!currentUser) return null
@@ -47,34 +45,11 @@ export function PostPrompt ({ forGroup, currentType, currentTopicName }) {
   }
 
   return (
-    <View style={styles.postPrompt}>
-      <TouchableOpacity onPress={handleOpenPostEditor} style={styles.promptButton}>
-        <Avatar avatarUrl={currentUser.avatarUrl} style={styles.avatar} />
-        <Text style={styles.promptText}>{postPromptString(currentType, currentUser, t)}</Text>
-      </TouchableOpacity>
-    </View>
+    <TouchableOpacity className='flex-row rounded-lg p-2 bg-primary m-1' style={styles.postPrompt} onPress={handleOpenPostEditor}>
+      <Plus style={{ color: rhino }} />
+      <Text style={{ marginRight: 5 }} className='text-xl'>Create</Text>
+    </TouchableOpacity>
   )
-}
-
-export function postPromptString (type = '', user, t) {
-  const firstName = getFirstName(user)
-  const postPrompts = {
-    offer: t('Hi {{firstName}}, what would you like to share?', { firstName }),
-    request: t('Hi {{firstName}}, what are you looking for?', { firstName }),
-    project: t('Hi {{firstName}}, what would you like to create?', { firstName }),
-    event: t('Hi {{firstName}}, want to create an event?', { firstName }),
-    default: t('Hi {{firstName}}, press here to post', { firstName })
-  }
-  return postPrompts[type] || postPrompts.default
-}
-
-const postPromptShape = {
-  position: 'absolute',
-  height: 52,
-  borderRadius: 2,
-  left: 0,
-  right: 0,
-  bottom: -26
 }
 
 const hasTextShadow = {
@@ -84,16 +59,9 @@ const hasTextShadow = {
 }
 
 const styles = StyleSheet.create({
-  bannerContainer: {
-    zIndex: 10,
-    height: 142,
-    marginBottom: 10,
-    flexDirection: 'column',
-    alignItems: 'flex-end',
-    justifyContent: 'flex-end'
-  },
-  bannerContainerWithPostPrompt: {
-    marginBottom: 34
+  headerContainer: {
+    alignItems: 'center',
+    justifyContent: 'center'
   },
   customViewIcon: {
     fontSize: 16,
@@ -110,22 +78,20 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgb(255, 255, 255)'
   },
   image: {
-    height: 142,
+    height: '100%',
     width: '100%',
     position: 'absolute'
   },
   gradient: {
-    height: 142,
+    // height: 142,
     width: '100%',
     position: 'absolute'
   },
-  titleRow: {
-    position: 'absolute',
-    left: 0,
-    bottom: 56,
-    marginHorizontal: 16,
+  header: {
+    padding: 10,
     flexDirection: 'row',
-    alignItems: 'flex-end'
+    alignItems: 'center',
+    justifyContent: 'space-between'
   },
   title: {
     flex: 1,
@@ -140,22 +106,9 @@ const styles = StyleSheet.create({
     ...hasTextShadow
   },
   postPrompt: {
-    ...postPromptShape,
-    paddingHorizontal: 12,
-    paddingVertical: 8,
-    backgroundColor: white,
-    borderWidth: isIOS ? 0 : 1,
-    borderColor: capeCod10
-  },
-  promptButton: {
-    flexDirection: 'row',
-    alignItems: 'center'
-  },
-  avatar: {
-    marginRight: 10
-  },
-  promptText: {
-    color: capeCod40,
-    fontSize: 14
+    alignItems: 'center',
+    justifyContent: 'flex-start',
+    fontColor: black
   }
+
 })

--- a/apps/mobile/src/screens/Stream/StreamHeader.js
+++ b/apps/mobile/src/screens/Stream/StreamHeader.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native'
 import { useNavigation } from '@react-navigation/native'
+import { useTranslation } from 'react-i18next'
 import FastImage from 'react-native-fast-image'
 import LinearGradient from 'react-native-linear-gradient'
 import useCurrentUser from '@hylo/hooks/useCurrentUser'
@@ -32,6 +33,7 @@ export default function StreamHeader ({ image, icon, name, postPrompt = false, c
 
 export function PostPrompt ({ forGroup, currentType, currentTopicName }) {
   const navigation = useNavigation()
+  const { t } = useTranslation
   const [{ currentUser }] = useCurrentUser()
 
   if (!currentUser) return null
@@ -47,7 +49,7 @@ export function PostPrompt ({ forGroup, currentType, currentTopicName }) {
   return (
     <TouchableOpacity className='flex-row rounded-lg p-2 bg-primary opacity-90' style={styles.postPrompt} onPress={handleOpenPostEditor}>
       <Plus style={{ color: rhino }} size={20} />
-      <Text style={{ marginRight: 5 }} className='text-l'>Create</Text>
+      <Text style={{ marginRight: 5 }} className='text-l'>{t('Create')}</Text>
     </TouchableOpacity>
   )
 }

--- a/apps/mobile/src/screens/Stream/StreamHeader.js
+++ b/apps/mobile/src/screens/Stream/StreamHeader.js
@@ -45,9 +45,9 @@ export function PostPrompt ({ forGroup, currentType, currentTopicName }) {
   }
 
   return (
-    <TouchableOpacity className='flex-row rounded-lg p-2 bg-primary m-1' style={styles.postPrompt} onPress={handleOpenPostEditor}>
-      <Plus style={{ color: rhino }} />
-      <Text style={{ marginRight: 5 }} className='text-xl'>Create</Text>
+    <TouchableOpacity className='flex-row rounded-lg p-2 bg-primary opacity-90' style={styles.postPrompt} onPress={handleOpenPostEditor}>
+      <Plus style={{ color: rhino }} size={20} />
+      <Text style={{ marginRight: 5 }} className='text-l'>Create</Text>
     </TouchableOpacity>
   )
 }
@@ -80,10 +80,10 @@ const styles = StyleSheet.create({
   image: {
     height: '100%',
     width: '100%',
-    position: 'absolute'
+    position: 'absolute',
+    opacity: 0.8
   },
   gradient: {
-    // height: 142,
     width: '100%',
     position: 'absolute'
   },

--- a/packages/presenters/ContextWidgetPresenter.js
+++ b/packages/presenters/ContextWidgetPresenter.js
@@ -311,5 +311,5 @@ export const COMMON_VIEWS = {
   welcome: {
     name: 'Welcome',
     iconName: 'Hand'
-  },
+  }
 }


### PR DESCRIPTION
- Properly handles context switching links and adds code in HomeNavigator re. flow of initialURL, returnToOnAuth, and context switching link handling (as it all happens in HomeNavigator)
- Makes TabNavigationHeader (the header almost always seen in Mobile) have a < left button always
- Gives mostly full width of header to title of group
- Keep title of group in header even on custom stream types, and moves the custom stream type name (e.g. Events, Proposals, etc) in the stream header
- Makes stream header much smaller and adds a "+ Create" button instead of the Post Prompt
- Fixes some things in Stream
- Extends openURL to have "options" as the second param, with `openURL(path, { reset: true})` now being the signature for what used to be `openURL(path, true)`. Adds options.replace option which should be what is generally always used when using openURL to navigate from either Drawer menu (ContextSwith or Context Menu) so that the Stack on the Home tab is reset by what is navigated to vs creating addiotnal screens/history in the stack. _Replace should probably not be used other than from this top level, as we like the history to be correct. Reset should never be used with the exception of the JoinGroup / Auth related places it is currently used._
- Updates ContextSwitch and ContextMenu (including widget paths) to navigate using replace as per above
- Gives TabNavigationHeader a white background and adjusts font and icon sizes somewhat
- Fixes issue with Map back navigation
- Minor UX improvement to Creation dialog to make it a bottom sheet