### PR TITLE
Proposed Mobile Context Menu component re-naming

### DIFF
--- a/apps/mobile/src/components/ContextMenu/ContextMenu.js
+++ b/apps/mobile/src/components/ContextMenu/ContextMenu.js
@@ -47,11 +47,11 @@ export default function ContextMenu () {
 
   return (
     <View className='flex-1 bg-background' style={{ paddingBottom: insets.bottom }}>
-      <Header group={currentGroup} />
+      <ContextHeader group={currentGroup} />
       <ScrollView className='p-2'>
         {widgets.map((widget, key) => (
           <View key={key} className='mb-0.5'>
-            <MenuItem
+            <ContextItem
               widget={widget}
               groupSlug={currentGroup.slug}
               rootPath={`/groups/${currentGroup.slug}`}
@@ -75,7 +75,29 @@ export default function ContextMenu () {
   )
 }
 
-function MenuItem ({ widget, groupSlug, rootPath, group }) {
+function ContextHeader ({ group, style }) {
+  const { t } = useTranslation()
+  const insets = useSafeAreaInsets()
+
+  if (!group) return null
+
+  return (
+    <View className='w-full relative' style={style}>
+      {!group.isContextGroup && (
+        <GroupMenuHeader group={group} />
+      )}
+      {group.isContextGroup && (
+        <View className='flex flex-col p-2' style={{ paddingTop: insets.top }}>
+          <Text className='text-foreground font-bold text-lg'>
+            {t(group.name)}
+          </Text>
+        </View>
+      )}
+    </View>
+  )
+}
+
+function ContextItem ({ widget, groupSlug, rootPath, group }) {
   const { t } = useTranslation()
   const { listItems, loading } = useContextWidgetChildren({ widget, groupSlug })
   const openURL = useOpenURL()
@@ -139,11 +161,11 @@ function MenuItem ({ widget, groupSlug, rootPath, group }) {
         <Text className={`text-base font-light opacity-50 ${isActive ? 'text-selected text-opacity-100' : 'text-foreground'}`}>{title}</Text>
       </TouchableOpacity>
       <View className='w-full flex flex-col justify-center items-center relative'>
-        <TopElements widget={widget} group={group} />
+        <ContextItemActions widget={widget} group={group} />
       </View>
       {loading && <Text className='text-foreground'>{t('Loading...')}</Text>}
       {listItems.length > 0 && listItems.map((item, key) =>
-        <ChildWidget
+        <ContextItemChild
           key={key}
           widget={item}
           rootPath={rootPath}
@@ -156,7 +178,7 @@ function MenuItem ({ widget, groupSlug, rootPath, group }) {
   )
 }
 
-function ChildWidget ({ widget, handleWidgetPress, rootPath, groupSlug, parentUrl }) {
+function ContextItemChild ({ widget, handleWidgetPress, rootPath, groupSlug, parentUrl }) {
   const { t } = useTranslation()
   const routeParams = useRouteParams()
   const url = makeWidgetUrl({ widget, rootPath, groupSlug })
@@ -185,28 +207,13 @@ function ChildWidget ({ widget, handleWidgetPress, rootPath, groupSlug, parentUr
   )
 }
 
-function TopElementLink ({ title, path }) {
-  const { t } = useTranslation()
-  const openURL = useOpenURL()
-  return (
-    <TouchableOpacity
-      onPress={() => openURL(path, { replace: true })}
-      className='w-full'
-    >
-      <View className='w-full border-2 border-foreground/20 rounded-md p-2 mb-2 bg-background'>
-        <Text className='text-base text-foreground'>{t(title)}</Text>
-      </View>
-    </TouchableOpacity>
-  )
-}
-
-function TopElements ({ widget, group }) {
+function ContextItemActions ({ widget, group }) {
   const hasResponsibility = useHasResponsibility({ forCurrentGroup: true, forCurrentUser: true })
   const canAddMembers = hasResponsibility(RESP_ADD_MEMBERS)
 
   if (widget.type === 'members' && canAddMembers) {
     return (
-      <TopElementLink title='Add Members' url={`/groups/${group.slug}/settings/invite`} />
+      <ContextItemActionLink title='Add Members' url={`/groups/${group.slug}/settings/invite`} />
     )
   }
 
@@ -223,26 +230,26 @@ function TopElements ({ widget, group }) {
     const settingsDetailsPath = `/groups/${group.slug}/settings/details`
     return (
       <View className='w-full mb-2'>
-        <TopElementLink title='Settings' path={`/groups/${group.slug}/settings`} />
+        <ContextItemActionLink title='Settings' path={`/groups/${group.slug}/settings`} />
         <View className='w-full'>
           {!group.avatarUrl && (
-            <TopElementLink title='Add Avatar' path={settingsDetailsPath} />
+            <ContextItemActionLink title='Add Avatar' path={settingsDetailsPath} />
           )}
           {!group.bannerUrl && (
-            <TopElementLink title='Add Banner' path={settingsDetailsPath} />
+            <ContextItemActionLink title='Add Banner' path={settingsDetailsPath} />
           )}
           {!group.purpose && (
-            <TopElementLink title='Add Purpose' path={settingsDetailsPath} />
+            <ContextItemActionLink title='Add Purpose' path={settingsDetailsPath} />
           )}
           {(
             !group.description ||
             group.description === 'This is a long-form description of the group' ||
             group.description === ''
           ) && (
-            <TopElementLink title='Add Description' path={settingsDetailsPath} />
+            <ContextItemActionLink title='Add Description' path={settingsDetailsPath} />
           )}
           {!group.locationObject && (
-            <TopElementLink title='Add Location' path={settingsDetailsPath} />
+            <ContextItemActionLink title='Add Location' path={settingsDetailsPath} />
           )}
         </View>
       </View>
@@ -250,24 +257,17 @@ function TopElements ({ widget, group }) {
   }
 }
 
-function Header ({ group, style }) {
+function ContextItemActionLink ({ title, path }) {
   const { t } = useTranslation()
-  const insets = useSafeAreaInsets()
-
-  if (!group) return null
-
+  const openURL = useOpenURL()
   return (
-    <View className='w-full relative' style={style}>
-      {!group.isContextGroup && (
-        <GroupMenuHeader group={group} />
-      )}
-      {group.isContextGroup && (
-        <View className='flex flex-col p-2' style={{ paddingTop: insets.top }}>
-          <Text className='text-foreground font-bold text-lg'>
-            {t(group.name)}
-          </Text>
-        </View>
-      )}
-    </View>
+    <TouchableOpacity
+      onPress={() => openURL(path, { replace: true })}
+      className='w-full'
+    >
+      <View className='w-full border-2 border-foreground/20 rounded-md p-2 mb-2 bg-background'>
+        <Text className='text-base text-foreground'>{t(title)}</Text>
+      </View>
+    </TouchableOpacity>
   )
 }

--- a/apps/mobile/src/components/ContextMenu/ContextMenu.js
+++ b/apps/mobile/src/components/ContextMenu/ContextMenu.js
@@ -63,11 +63,10 @@ export default function ContextMenu () {
       <ScrollView className='p-2'>
         {widgets.map((widget, key) => (
           <View key={key} className='mb-0.5'>
-            <ContextItem
+            <ContextWidget
               widget={widget}
               groupSlug={currentGroup.slug}
               rootPath={`/groups/${currentGroup.slug}`}
-              group={currentGroup}
             />
           </View>
         ))}
@@ -87,9 +86,9 @@ export default function ContextMenu () {
   )
 }
 
-function ContextItem ({ widget, groupSlug }) {
+function ContextWidget ({ widget, groupSlug }) {
   const { t } = useTranslation()
-  const { listItems, loading } = useContextWidgetChildren({ widget, groupSlug })
+  const { listItems: childWidgets, loading } = useContextWidgetChildren({ widget, groupSlug })
   const openURL = useOpenURL()
   const logout = useLogout()
   const hasResponsibility = useHasResponsibility({ forCurrentGroup: true, forCurrentUser: true })
@@ -150,13 +149,13 @@ function ContextItem ({ widget, groupSlug }) {
         <Text className={`text-base font-light opacity-50 ${isActive ? 'text-selected text-opacity-100' : 'text-foreground'}`}>{title}</Text>
       </TouchableOpacity>
       <View className='w-full flex flex-col justify-center items-center relative'>
-        <ContextItemActions widget={widget} />
+        <ContextWidgetActions widget={widget} />
       </View>
       {loading && <Text className='text-foreground'>{t('Loading...')}</Text>}
-      {listItems.length > 0 && listItems.map((item, key) =>
-        <ContextItemChild
+      {childWidgets.length > 0 && childWidgets.map((childWidget, key) =>
+        <ContextWidgetChild
           key={key}
-          widget={item}
+          widget={childWidget}
           rootPath={rootPath}
           groupSlug={groupSlug}
           handleWidgetPress={handleWidgetPress}
@@ -166,7 +165,7 @@ function ContextItem ({ widget, groupSlug }) {
   )
 }
 
-function ContextItemChild ({ widget, handleWidgetPress, rootPath, groupSlug }) {
+function ContextWidgetChild ({ widget, handleWidgetPress, rootPath, groupSlug }) {
   const { t } = useTranslation()
   const routeParams = useRouteParams()
   const url = makeWidgetUrl({ widget, rootPath, groupSlug })
@@ -195,7 +194,7 @@ function ContextItemChild ({ widget, handleWidgetPress, rootPath, groupSlug }) {
   )
 }
 
-function ContextItemActions ({ widget }) {
+function ContextWidgetActions ({ widget }) {
   const [{ currentGroup }] = useCurrentGroup()
   const hasResponsibility = useHasResponsibility({ forCurrentGroup: true, forCurrentUser: true })
   const canAddMembers = hasResponsibility(RESP_ADD_MEMBERS)
@@ -204,7 +203,7 @@ function ContextItemActions ({ widget }) {
 
   if (widget.type === 'members' && canAddMembers) {
     return (
-      <ContextItemActionLink title='Add Members' widget={widget} path={`/groups/${currentGroup.slug}/settings/invite`} />
+      <ContextWidgetActionLink title='Add Members' widget={widget} path={`/groups/${currentGroup.slug}/settings/invite`} />
     )
   }
 
@@ -221,26 +220,26 @@ function ContextItemActions ({ widget }) {
     const settingsDetailsPath = `/groups/${currentGroup.slug}/settings/details`
     return (
       <View className='w-full mb-2'>
-        <ContextItemActionLink title='Settings' path={`/groups/${currentGroup.slug}/settings`} />
+        <ContextWidgetActionLink title='Settings' path={`/groups/${currentGroup.slug}/settings`} />
         <View className='w-full'>
           {!currentGroup.avatarUrl && (
-            <ContextItemActionLink title='Add Avatar' path={settingsDetailsPath} />
+            <ContextWidgetActionLink title='Add Avatar' path={settingsDetailsPath} />
           )}
           {!currentGroup.bannerUrl && (
-            <ContextItemActionLink title='Add Banner' path={settingsDetailsPath} />
+            <ContextWidgetActionLink title='Add Banner' path={settingsDetailsPath} />
           )}
           {!currentGroup.purpose && (
-            <ContextItemActionLink title='Add Purpose' path={settingsDetailsPath} />
+            <ContextWidgetActionLink title='Add Purpose' path={settingsDetailsPath} />
           )}
           {(
             !currentGroup.description ||
             currentGroup.description === 'This is a long-form description of the group' ||
             currentGroup.description === ''
           ) && (
-            <ContextItemActionLink title='Add Description' path={settingsDetailsPath} />
+            <ContextWidgetActionLink title='Add Description' path={settingsDetailsPath} />
           )}
           {!currentGroup.locationObject && (
-            <ContextItemActionLink title='Add Location' path={settingsDetailsPath} />
+            <ContextWidgetActionLink title='Add Location' path={settingsDetailsPath} />
           )}
         </View>
       </View>
@@ -248,7 +247,7 @@ function ContextItemActions ({ widget }) {
   }
 }
 
-function ContextItemActionLink ({ title, path, widget }) {
+function ContextWidgetActionLink ({ title, path, widget }) {
   const { t } = useTranslation()
   const openURL = useOpenURL()
 


### PR DESCRIPTION
@thomasgwatson in stages I'm getting a much more clear understanding of the ContextWidget architecture and the related ContextMenu. This commit is a proposal of "for now" renaming of the internal ContextMenu components to a scheme which, at least for me, is more clear and descriptive than what is currently there. This doesn't have to be forever or perfect, but for now would definitely help me to work and make some refinements in this area. Let me know if you have any objections, clarifications, adjustments, otherwise if you hate it. If you are good with it and it makes enough sense for you, I'd like to merge this into my current work on https://github.com/Hylozoic/hylo/pull/383 as I'll likely continue with some additional small UI/UX updates in this area by the time I'm done there. 

_I do understand that this is all divergent from Web in terms of component naming, and for me that is fine. There is perhaps some ontology here which Web can usefully inherit as the same area gets refined over time, and for now will give me at least something I feel much more clear and confident working with.  I also imagine there are several features (e.g. the in-menu Member list, etc) which are not yet implemented here in the Mobile ContextMenu, and will expect that some of what is here will get shuffled, renamed, or otherwise further re-factored was we get that stuff together._ 