### PR TITLE
chore(backend,web,mobile): Sanitize CustomView#externalLink on query

### DIFF
--- a/apps/backend/api/graphql/makeModels.js
+++ b/apps/backend/api/graphql/makeModels.js
@@ -1,5 +1,6 @@
 import { camelCase, mapKeys, startCase } from 'lodash/fp'
 import pluralize from 'pluralize'
+import { TextHelpers } from '@hylo/shared'
 import searchQuerySet from './searchQuerySet'
 import {
   commentFilter,
@@ -791,7 +792,6 @@ export default function makeModels (userId, isAdmin, apiClient) {
         'collection_id',
         'default_sort',
         'default_view_mode',
-        'external_link',
         'group_id',
         'icon',
         'is_active',
@@ -801,6 +801,9 @@ export default function makeModels (userId, isAdmin, apiClient) {
         'type',
         'search_text'
       ],
+      getters: {
+        externalLink: customView => TextHelpers.sanitizeURL(customView.get('external_link'))
+      },
       relations: [
         'collection',
         'group',

--- a/apps/mobile/src/components/ContextMenu/ContextMenu.js
+++ b/apps/mobile/src/components/ContextMenu/ContextMenu.js
@@ -105,8 +105,9 @@ function ContextWidget ({ widget, groupSlug }) {
   }, [widgetPath, routeParams.originalLinkingPath])
 
   const handleWidgetPress = widget => {
-    const linkingPath = makeWidgetUrl({ widget, rootPath, groupSlug })
-    openURL(linkingPath, { replace: true })
+    widget?.customView?.externalLink
+      ? openURL(widget.customView.externalLink)
+      : openURL(makeWidgetUrl({ widget, rootPath, groupSlug }), { replace: true })
   }
 
   if (!widget || isHiddenInContextMenuResolver(widget) || (widget.visibility === 'admin' && !canAdmin)) {

--- a/apps/mobile/src/screens/AllViews/AllViews.js
+++ b/apps/mobile/src/screens/AllViews/AllViews.js
@@ -1,7 +1,6 @@
 import React, { useMemo } from 'react'
 import { View, Text, ScrollView, TouchableOpacity } from 'react-native'
 import { useTranslation } from 'react-i18next'
-import { capitalize } from 'lodash/fp'
 import useHasResponsibility, { RESP_ADMINISTRATION } from '@hylo/hooks/useHasResponsibility'
 import { translateTitle } from '@hylo/presenters/ContextWidgetPresenter'
 import useCurrentGroup from '@hylo/hooks/useCurrentGroup'
@@ -52,14 +51,10 @@ export default function AllViews () {
     })
   }, [widgets, canAdminister])
 
-  const handleWidgetPress = (widget) => {
-    const widgetUrl = makeWidgetUrl({ widget, groupSlug: currentGroup?.slug })
-
-    if (widgetUrl) {
-      openURL(widgetUrl)
-    } else {
-      console.warn('Could not determine navigation for widget:', widget)
-    }
+  const handleWidgetPress = widget => {
+    widget?.customView?.externalLink
+      ? openURL(widget.customView.externalLink)
+      : openURL(makeWidgetUrl({ widget, groupSlug: currentGroup?.slug }))
   }
 
   return (

--- a/apps/web/src/routes/AuthLayoutRouter/components/ContextMenu/MenuLink/MenuLink.jsx
+++ b/apps/web/src/routes/AuthLayoutRouter/components/ContextMenu/MenuLink/MenuLink.jsx
@@ -17,12 +17,8 @@ export default function MenuLink ({ badgeCount = null, to, children, onClick, ex
   }, [onClick])
 
   if (externalLink) {
-    const url = externalLink.startsWith('http://') || externalLink.startsWith('https://')
-      ? externalLink
-      : `https://${externalLink}`
-
     return (
-      <a href={url} target='_blank' rel='noreferrer' onClick={onClick} className={cn('MenuLink text-foreground text-sm', className, { 'opacity-100 border-selected': isCurrentLocation })}>
+      <a href={externalLink} target='_blank' rel='noreferrer' onClick={onClick} className={cn('MenuLink text-foreground text-sm', className, { 'opacity-100 border-selected': isCurrentLocation })}>
         {children}
       </a>
     )


### PR DESCRIPTION
_We also might just want to for now abandon relying on the navigation helpers in both apps for ContextWidgets links for now (until that area is sorted and shared) and just put the `widgetUrl` helper in `ContextWidgetPresenter` and add a `presentedWidget#link({ groupSlug, rootPath, ... })` attribute on the presented Widget... Won't do that here, but that would simplify the Web and Mobile code and guarantee we were always getting the same path in both apps for the same `ContextWidget`._  