### PR TITLE
chore(web): Makes center column scrollable again in WebViews (settings pages)

### DIFF
--- a/apps/web/src/routes/AuthLayoutRouter/AuthLayoutRouter.module.scss
+++ b/apps/web/src/routes/AuthLayoutRouter/AuthLayoutRouter.module.scss
@@ -328,7 +328,7 @@ $drawer-z-index: 51;
   min-height: 1px; // Prevent collapsing
   height: 100%;
   flex: 1;
-  overflow: scroll;
+  overflow: auto;
   // transition: all .45s ease; // Took this out because it was causing issues with the width of the map
 
   &.full-width {

--- a/apps/web/src/routes/AuthLayoutRouter/AuthLayoutRouter.module.scss
+++ b/apps/web/src/routes/AuthLayoutRouter/AuthLayoutRouter.module.scss
@@ -328,7 +328,7 @@ $drawer-z-index: 51;
   min-height: 1px; // Prevent collapsing
   height: 100%;
   flex: 1;
-  overflow: hidden;
+  overflow: scroll;
   // transition: all .45s ease; // Took this out because it was causing issues with the width of the map
 
   &.full-width {


### PR DESCRIPTION
In Mobile WebView usage the Group Settings areas are not scrollable without overflow being set to scroll for the center column. This change to hide the overflow was added in [48dab6b](https://github.com/Hylozoic/hylo/commit/48dad6be5b2aef1762d9cfd17c1a9ebd535afe0f) which was part of a changeset to fix the recently appearing new white extra bar on the right side of all WebView pages. Unfortunately that changeset did not change the appearance in the app in these WebViews, the white bar is still there and went unchanged. Reverting this one setting for now makes things not broken, so think we should move this forward and address the larger issue as another pass.

See the white bar in the screen shots. They appear with or without this overflow setting set to scroll:

![Simulator Screenshot - iPhone 16 Pro Max - 2025-03-16 at 01 57 41](https://github.com/user-attachments/assets/f175c51f-263e-48c1-b153-b59c6bff00ef)

![Simulator Screenshot - iPhone 16 Pro Max - 2025-03-16 at 01 56 21](https://github.com/user-attachments/assets/9770ae33-62a1-4ab5-be8a-cda0de40bd6d)
