### PR TITLE
Mobile: Android Review Fixes

### DIFF
--- a/apps/mobile/android/app/build.gradle
+++ b/apps/mobile/android/app/build.gradle
@@ -131,6 +131,9 @@ dependencies {
 
     implementation "androidx.core:core-splashscreen:1.0.0"
     implementation "com.onesignal:OneSignal:[5.0.0, 5.99.99]"
+    // react-native-image-picker requirement for minSdkVersion < 30:
+    // https://github.com/react-native-image-picker/react-native-image-picker?tab=readme-ov-file#android-1
+    implementation("androidx.activity:activity:1.9.+")
 
     if (hermesEnabled.toBoolean()) {
         implementation("com.facebook.react:hermes-android")

--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
@@ -27,11 +27,23 @@
       android:name="com.onesignal.NotificationServiceExtension"
       android:value="com.hylo.hyloandroid.NotificationServiceExtension" />
     <meta-data
-        android:name="com.onesignal.messaging.default_notification_icon"
-        android:resource="@drawable/ic_stat_onesignal_default" />
+      android:name="com.onesignal.messaging.default_notification_icon"
+      android:resource="@drawable/ic_stat_onesignal_default" />
     <meta-data
-        android:name="com.onesignal.NotificationAccentColor.DEFAULT"
-        android:value="FFFFFF" />
+      android:name="com.onesignal.NotificationAccentColor.DEFAULT"
+      android:value="FFFFFF" />
+    <!-- Trigger Google Play services to install the backported photo picker module. -->
+    <!-- react-native-image-picker requirement for minSdkVersion < 30 -->
+    <service
+      android:name="com.google.android.gms.metadata.ModuleDependencies"
+      android:enabled="false"
+      android:exported="false"
+      tools:ignore="MissingClass">
+      <intent-filter>
+          <action android:name="com.google.android.gms.metadata.MODULE_DEPENDENCIES" />
+      </intent-filter>
+      <meta-data android:name="photopicker_activity:0:required" android:value="" />
+    </service>
     <activity
       android:name=".MainActivity"
       android:label="@string/app_name"

--- a/apps/mobile/ios/Podfile.lock
+++ b/apps/mobile/ios/Podfile.lock
@@ -1359,7 +1359,7 @@ PODS:
     - React-Core
   - react-native-geolocation-service (5.3.1):
     - React
-  - react-native-image-picker (7.2.3):
+  - react-native-image-picker (8.2.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2536,7 +2536,7 @@ SPEC CHECKSUMS:
   react-native-date-picker: 26cdb1a94ec72dbc9210c3379e57ff6ba8bc73f2
   react-native-document-picker: a338165804b1a14c8e408448115dc0edfd7b73ca
   react-native-geolocation-service: 32b2c2a3b91e70ce2a8d0c684801aaeb0a07e0ec
-  react-native-image-picker: 91f4e8dd458db2acdb278479e960bc224cbf0217
+  react-native-image-picker: 732212151b686ff27ff57a7ea90f5d07d1a0c813
   react-native-onesignal: 1795c532f8bd86c3307a032621c17d85998402d0
   react-native-pager-view: 4ad4883a8288c5207bd432dd3c98bf648b7bc7d7
   react-native-render-html: 5afc4751f1a98621b3009432ef84c47019dcb2bd

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -87,7 +87,7 @@
     "react-native-fast-image": "^8.6.3",
     "react-native-geolocation-service": "^5.3.1",
     "react-native-gesture-handler": "^2.22.0",
-    "react-native-image-picker": "^7.2.3",
+    "react-native-image-picker": "^8.2.0",
     "react-native-image-viewing": "^0.2.2",
     "react-native-keyboard-manager": "^6.5.16-0",
     "react-native-linear-gradient": "^2.8.3",

--- a/apps/mobile/src/components/ContextMenu/ContextMenu.js
+++ b/apps/mobile/src/components/ContextMenu/ContextMenu.js
@@ -13,6 +13,7 @@ import {
 } from '@hylo/presenters/ContextWidgetPresenter'
 import useContextWidgetChildren from '@hylo/hooks/useContextWidgetChildren'
 import useHasResponsibility, { RESP_ADD_MEMBERS, RESP_ADMINISTRATION } from '@hylo/hooks/useHasResponsibility'
+import { isIOS } from 'util/platform'
 import { widgetUrl as makeWidgetUrl } from 'util/navigation'
 import useLogout from 'hooks/useLogout'
 import useOpenURL from 'hooks/useOpenURL'
@@ -32,13 +33,13 @@ export default function ContextMenu () {
   if (!currentGroup) return null
 
   return (
-    <View className='flex-1 bg-background' style={{ paddingBottom: insets.bottom }}>
+    <View className='flex-1 bg-background'>
       <View>
         {!currentGroup.isStaticContext && (
           <GroupMenuHeader group={currentGroup} />
         )}
         {currentGroup.isStaticContext && (
-          <View className='flex-col p-2' style={{ paddingTop: insets.top }}>
+          <View className='flex-col p-2' style={{ paddingTop: insets.top + (isIOS ? 0 : 20) }}>
             <Text className='text-foreground font-bold text-lg'>
               {t(currentGroup.name)}
             </Text>
@@ -55,16 +56,17 @@ export default function ContextMenu () {
             />
           </View>
         ))}
+        {!currentGroup.isStaticContext && (
+          <View className='mb-0.5'>
+            <ContextWidget
+              widget={allViewsWidget}
+              groupSlug={currentGroup.slug}
+              rootPath={`/groups/${currentGroup.slug}`}
+            />
+          </View>
+        )}
+        <View style={{ marginBottom: insets.bottom + 20 }} />
       </ScrollView>
-      {!currentGroup.isStaticContext && (
-        <View className='px-2 mb-2'>
-          <ContextWidget
-            widget={allViewsWidget}
-            groupSlug={currentGroup.slug}
-            rootPath={`/groups/${currentGroup.slug}`}
-          />
-        </View>
-      )}
     </View>
   )
 }
@@ -100,16 +102,18 @@ function ContextWidget ({ widget, groupSlug }) {
 
   if (widgetPath && (widget.childWidgets.length === 0 && !['members', 'about'].includes(widget.type))) {
     return (
-      <TouchableOpacity
-        onPress={() => handleWidgetPress(widget)}
-        className={`
-          flex-row items-center p-3 bg-background border-2 rounded-md mb-2 gap-2
-          ${isActive ? 'border-selected opacity-100' : 'border-foreground/20'}
-        `}
-      >
-        <WidgetIconResolver widget={widget} />
-        <Text className='text-base font-normal text-foreground'>{title}</Text>
-      </TouchableOpacity>
+      <View className='rounded-md p-2 bg-background mb-0.5'>
+        <TouchableOpacity
+          onPress={() => handleWidgetPress(widget)}
+          className={`
+            flex-row items-center p-3 bg-background border-2 rounded-md mb-2 gap-2
+            ${isActive ? 'border-selected opacity-100' : 'border-foreground/20'}
+          `}
+        >
+          <WidgetIconResolver widget={widget} />
+          <Text className='text-base font-normal text-foreground'>{title}</Text>
+        </TouchableOpacity>
+      </View>
     )
   }
 
@@ -123,7 +127,9 @@ function ContextWidget ({ widget, groupSlug }) {
       </TouchableOpacity>
       <View>
         <ContextWidgetActions widget={widget} />
-        {loading && <Text className='text-foreground'>{t('Loading...')}</Text>}
+        {loading && (
+          <Text className='text-foreground'>{t('Loading...')}</Text>
+        )}
         {widgetChildren.map((childWidget, key) =>
           <ContextWidgetChild
             key={key}

--- a/apps/mobile/src/components/ContextSwitchMenu/ContextSwitchMenu.js
+++ b/apps/mobile/src/components/ContextSwitchMenu/ContextSwitchMenu.js
@@ -10,6 +10,7 @@ import useCurrentUser from '@hylo/hooks/useCurrentUser'
 import useCurrentGroup from '@hylo/hooks/useCurrentGroup'
 import useStaticContexts from '@hylo/hooks/useStaticContexts'
 import { useChangeToGroup } from 'hooks/useHandleCurrentGroup'
+import { isIOS } from 'util/platform'
 import useOpenURL from 'hooks/useOpenURL'
 import LucideIcon from 'components/LucideIcon'
 import { black, white } from 'style/colors'
@@ -54,7 +55,7 @@ export default function ContextSwitchMenu ({ isExpanded, setIsExpanded }) {
   return (
     <View
       className='h-full bg-theme-background z-50'
-      style={{ paddingTop: insets.top, paddingBottom: insets.bottom }}
+      style={{ paddingTop: insets.top + (isIOS ? 0 : 20), paddingBottom: insets.bottom + (isIOS ? 0 : 20) }}
     >
       <FlatList
         data={myGroups}

--- a/apps/mobile/src/components/GroupMenuHeader/GroupMenuHeader.js
+++ b/apps/mobile/src/components/GroupMenuHeader/GroupMenuHeader.js
@@ -2,12 +2,14 @@ import React, { useState, useEffect } from 'react'
 import { Settings, Users, ChevronRight } from 'lucide-react-native'
 import { View, Text, TouchableOpacity } from 'react-native'
 import clsx from 'clsx'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useTranslation } from 'react-i18next'
 import FastImage from 'react-native-fast-image'
 import useOpenURL from 'hooks/useOpenURL'
 import useHasResponsibility, { RESP_ADMINISTRATION } from '@hylo/hooks/useHasResponsibility'
 
 export default function GroupMenuHeader ({ group }) {
+  const insets = useSafeAreaInsets()
   const { t } = useTranslation()
   const openURL = useOpenURL()
   const avatarUrl = group.avatarUrl
@@ -27,7 +29,10 @@ export default function GroupMenuHeader ({ group }) {
   }, [bannerUrl])
 
   return (
-    <View className='relative flex-col justify-end h-[140px] shadow-md pb-2' testID='group-header'>
+    <View
+      styleName={{ paddingTop: insets.top }}
+      className='relative flex-col justify-end h-[140px] shadow-md pb-2'
+    >
       <FastImage
         source={{ uri: bannerUrl }}
         style={{

--- a/apps/mobile/src/components/HyloWebView/HyloWebView.js
+++ b/apps/mobile/src/components/HyloWebView/HyloWebView.js
@@ -16,7 +16,7 @@ const handledWebRoutesJavascriptCreator = loadedPath => allowRoutesParam => {
   const handledWebRoutesRegExpsLiteralString = JSON.parse(JSON.stringify(handledWebRoutesRegExps.map(a => a.toString())))
 
   return `
-    function addHyloWebViewListener (history) {
+    window.addHyloWebViewListener = function (history) {
       if (history) {
         history.listen(({ location: { pathname, search } }) => {
           const handledWebRoutesRegExps = [${handledWebRoutesRegExpsLiteralString}]

--- a/apps/mobile/src/hooks/useHyloActionSheet.js
+++ b/apps/mobile/src/hooks/useHyloActionSheet.js
@@ -74,12 +74,11 @@ export default function useHyloActionSheet () {
           // Great options for adding more context (e.g. Title of Post, etc)
           // title: '',
           // message: '',
-          // Above params are compataible with RN iOS ActionSheet
+          // Above params are compatible with RN iOS ActionSheet
           // The following params are specific to `@expo/react-native-action-sheet`
           // and only relevant for Android.
           icons,
           showSeparators: true,
-          autoFocus: true,
           containerStyle: { padding: 10 },
           textStyle: { fontSize: 18 },
           ...overrideParams

--- a/apps/mobile/src/navigation/headers/TabStackHeader.js
+++ b/apps/mobile/src/navigation/headers/TabStackHeader.js
@@ -31,11 +31,11 @@ export default function TabStackHeader ({
     headerTitleContainerStyle: {
       // Follow: https://github.com/react-navigation/react-navigation/issues/7057#issuecomment-593086348
       alignItems: 'left',
-      marginLeft: isIOS ? 10 : 20
+      marginLeft: isIOS ? 10 : 0
     },
     headerTitleStyle: {
       fontFamily: 'Circular-Bold',
-      fontSize: 16
+      fontSize: 18
     },
     headerTitleAlign: 'left',
     headerStyle: {
@@ -88,7 +88,8 @@ export const styles = StyleSheet.create({
     alignItems: 'center'
   },
   backIcon: {
-    marginHorizontal: 5
+    marginLeft: isIOS ? 5 : -8,
+    marginRight: isIOS ? 5 : 5
   },
   avatar: {
     width: 30,

--- a/apps/mobile/src/screens/CreateGroup/CreateGroup.js
+++ b/apps/mobile/src/screens/CreateGroup/CreateGroup.js
@@ -52,24 +52,28 @@ export default function CreateGroup ({ navigation }) {
   }
 
   return (
-    <KeyboardAvoidingView behavior={isIOS ? 'padding' : ''} style={{ flex: 1 }} enabled>
-      <View style={[
-        styles.header,
-        {
-          paddingTop: insets.top
-        }]
-      }>
+    <KeyboardAvoidingView
+      behavior={isIOS ? 'padding' : ''}
+      className='bg-background'
+      style={{ flex: 1 }}
+      enabled
+    >
+      <View style={[styles.header, { paddingTop: insets.top }]}>
         <X onPress={handleCancel} />
         <Text>{`${currentStep + 1}/${totalSteps}`}</Text>
       </View>
-      <ScrollView contentContainerClassName='bg-background' contentContainerStyle={styles.screen} keyboardDismissMode='on-drag' keyboardShouldPersistTaps='handled'>
+      <ScrollView
+        contentContainerStyle={styles.screen}
+        keyboardDismissMode='on-drag'
+        keyboardShouldPersistTaps='handled'
+      >
         <CurrentScreen />
       </ScrollView>
       <View
         style={[
           styles.workflowNav,
           {
-            paddingBottom: keyboardVisible ? 10 : insets.bottom,
+            paddingBottom: keyboardVisible ? 10 : insets.bottom + (isIOS ? 0 : 20),
             paddingLeft: insets.left + 10,
             paddingRight: insets.right + 10
           }
@@ -118,7 +122,6 @@ const styles = StyleSheet.create({
     paddingRight: 20
   },
   screen: {
-    flex: 1,
     padding: 20
   },
   workflowNav: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -25442,7 +25442,7 @@ __metadata:
     react-native-fast-image: "npm:^8.6.3"
     react-native-geolocation-service: "npm:^5.3.1"
     react-native-gesture-handler: "npm:^2.22.0"
-    react-native-image-picker: "npm:^7.2.3"
+    react-native-image-picker: "npm:^8.2.0"
     react-native-image-viewing: "npm:^0.2.2"
     react-native-keyboard-manager: "npm:^6.5.16-0"
     react-native-linear-gradient: "npm:^2.8.3"
@@ -30043,13 +30043,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-image-picker@npm:^7.2.3":
-  version: 7.2.3
-  resolution: "react-native-image-picker@npm:7.2.3"
+"react-native-image-picker@npm:^8.2.0":
+  version: 8.2.0
+  resolution: "react-native-image-picker@npm:8.2.0"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10/62c6cc3c88edb29f2b17b4cdaa098b32efd23a5faf4380171c2ccfb1706c732a50553f2ce447e1df1ea48197dde3af42dd67584c60e2c4577ee1b7769152475d
+  checksum: 10/9dac95436b7ffd714293d0c48b0a2a0520f7c94b3ff18325b5e57c9718f56eca6922836477e07d3c9a2c346a63bb9123d912d9c090495021acf587eb32a1733d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Ok, I spent several hours going over Android and remedied the most egregious issues including but not exclusive to (I can’t remember them all now):

- In WebView moves the `addHyloWebViewListener` function onto `window` in a way that is compatible with both WebKit/iOS and Chrome/Android fixing the "WebView’s are cooked” :) issue on Android.
- Action sheet and image picker both were appearing behind the screen in Android such that they were not visible and would make the app feel frozen unless the user was smart and pressed the android back button. Two different fixes, and now those work.
- Various Android differences with spacing form `TabStackHeader` backbutton + group icon + group name, to `ContextMenu` interactions with safe area (the fix here will also fix iOS for you @tibetsprague such that the gear icon in the group header was going outside the safe area)
- Create Group Review was not scrollable on Android, now fixed in a way that makes the implementation slightly more correct for iOS too (which is often the case with things that need fixed for Android)
- Updates `react-native-image-picker` up one major version and applies Android specific code for making it backward compatible with older versions of Android (which we officially support according to our set Android minSdkVersion which is coming from React Native defaults for 0.76.x). ⚠️ Clean rebuild iOS and Android including pod install is required due to these updates.
- Restructures context widget rendering in `ContextMenu` somewhat to no longer offset Logout and All Views widgets, putting in line with Web (and in the scope of this PR making it easier to get the spacing right for both platforms)

Adding 3 critical remaining known issues which need to be tested / fixed to the Mobile release TODO list. There are almost certainly other ones I've not yet found or fixed, so Android should be tested further.
