### PR TITLE
chore(mobile): Fixes Android deep linking configuration

### DIFF
--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
     android:icon="@mipmap/ic_launcher"
     android:roundIcon="@mipmap/ic_launcher_round"
     android:allowBackup="false"
-    android:theme="@style/BootTheme"
+    android:theme="@style/AppTheme"
     android:supportsRtl="true">
     <meta-data
       android:name="com.facebook.sdk.ApplicationId"
@@ -56,19 +56,16 @@
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />
       </intent-filter>
-
+      <!-- Deep linking intent-filter moved from MainActivity to react-native-boot-splash as per setup instructions -->
       <intent-filter android:autoVerify="true">
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />
-        <data android:scheme="@string/link_schema" />
-        <data
-          android:scheme="https"
-          android:host="www.hylo.com" />
-        <data
-          android:scheme="https"
-          android:host="staging.hylo.com" />
+        <data android:scheme="https" />
         <data android:scheme="hyloapp" />
+        <data android:scheme="@string/link_schema" />
+        <data android:host="www.hylo.com" />
+        <data android:host="staging.hylo.com" />
       </intent-filter>
     </activity>
   </application>

--- a/apps/mobile/android/app/src/main/res/values/strings.xml
+++ b/apps/mobile/android/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Hylo</string>
-    <string name="link_schema">HyloApp</string>
+    <string name="link_schema">hyloapp</string>
     <string name="facebook_app_id">Facebook App ID</string>
     <string name="facebook_client_token">Facebook Client ID</string>
     <string name="onesignal_notification_accent_color">FF0DC39F</string>

--- a/apps/mobile/scripts/open-link.sh
+++ b/apps/mobile/scripts/open-link.sh
@@ -4,7 +4,7 @@
 # this version just gives us more flexibility, is easier to type, and doesn't require installing
 # uri-scheme globally or having to wait it to download each time
 
-SCHEME="hyloapp://"
+SCHEME="https://www.hylo.com/"
 PLATFORM="ios"
 
 # Function to show usage
@@ -51,5 +51,5 @@ echo "Opening deep link: $DEEP_LINK on $PLATFORM..."
 if [ "$PLATFORM" == "ios" ]; then
   xcrun simctl openurl booted "$DEEP_LINK"
 else
-  adb shell am start -a android.intent.action.VIEW -d "$DEEP_LINK"
+  adb shell am start -W -a android.intent.action.VIEW -d "$DEEP_LINK" com.hylo.hyloandroid
 fi


### PR DESCRIPTION
Not entirely sure it was broken before, but these changes are all clarifying and fixes the open-link helper as well as confirms deep linking is now working in Android. 