### PR TITLE
go back to search when closing postDetail modal

### DIFF
--- a/apps/web/src/components/PostDialog/PostDialog.jsx
+++ b/apps/web/src/components/PostDialog/PostDialog.jsx
@@ -15,7 +15,7 @@ const PostDialog = ({
   const handleOpenChange = useCallback((open) => {
     if (!open) {
       // remove post/:postId from the url
-      navigate(removePostFromUrl(`${location.pathname}`))
+      navigate(removePostFromUrl(location.pathname))
     }
   }, [])
 

--- a/apps/web/src/components/PostDialog/PostDialog.jsx
+++ b/apps/web/src/components/PostDialog/PostDialog.jsx
@@ -15,7 +15,7 @@ const PostDialog = ({
   const handleOpenChange = useCallback((open) => {
     if (!open) {
       // remove post/:postId from the url
-      navigate(removePostFromUrl(`${location.pathname}${location.search}`))
+      navigate(removePostFromUrl(`${location.pathname}`))
     }
   }, [])
 


### PR DESCRIPTION
closes #430 

Tibet, please test -- I'm not able to test on dev, I get the attached errors. tbh I think this can solve the issue.

<img width="482" alt="Screenshot 2025-03-20 at 7 41 34 PM" src="https://github.com/user-attachments/assets/c4669bf6-68c5-41fe-9f58-d95362b913ea" />
<img width="555" alt="Screenshot 2025-03-20 at 7 41 43 PM" src="https://github.com/user-attachments/assets/e6677f6f-fee8-47c1-a114-142ea2499db0" />
