### PR TITLE
408 preview auto plays

### DIFF
--- a/apps/mobile/src/screens/GroupWelcome/GroupWelcome.js
+++ b/apps/mobile/src/screens/GroupWelcome/GroupWelcome.js
@@ -21,6 +21,7 @@ import GroupWelcomeTabBar from 'screens/GroupWelcome/GroupWelcomeTabBar'
 import HyloHTML from 'components/HyloHTML'
 import Pill from 'components/Pill'
 import styles from 'screens/GroupWelcome/GroupWelcome.styles'
+import { isIOS } from 'util/platform'
 import { caribbeanGreen } from 'style/colors'
 
 export const addSkillMutation = gql`
@@ -72,9 +73,9 @@ export default function GroupWelcome () {
   const [allQuestionsAnswered, setAllQuestionsAnswered] = useState(!currentGroup?.settings?.askJoinQuestions || !!joinQuestionsAnsweredAt)
 
   useEffect(() => {
-    KeyboardManager.setEnable(true)
+    if (isIOS) KeyboardManager.setEnable(true)
     return () => {
-      KeyboardManager.setEnable(false)
+      if (isIOS) KeyboardManager.setEnable(false)
     }
   }, [])
 

--- a/apps/web/src/routes/ChatRoom/ChatPost/ChatPost.js
+++ b/apps/web/src/routes/ChatRoom/ChatPost/ChatPost.js
@@ -304,8 +304,11 @@ export default function ChatPost ({
           delay={250}
           id='flag-tt'
         />
-        {linkPreview?.url && linkPreviewFeatured && isVideo && (
+        {linkPreview?.url && linkPreviewFeatured && isVideo && !isWebView() && (
           <Feature url={linkPreview.url} />
+        )}
+        {isWebView() && linkPreviewFeatured && (
+          <LinkPreview {...pick(['title', 'description', 'imageUrl', 'url'], linkPreview)} className={styles.linkPreview} />
         )}
         {linkPreview && !linkPreviewFeatured && (
           <LinkPreview {...pick(['title', 'description', 'imageUrl', 'url'], linkPreview)} className={styles.linkPreview} />


### PR DESCRIPTION
Basically this stops the use of react-player for webViews in mobile. Instead it renders a regular preview. Closes #408

I tested this on Android and encountered an unrelated issue, where we hadn't escaped the use of KeyboardManager (iOS only) for Android users.

![Screenshot 2025-03-24 at 11 04 28 AM](https://github.com/user-attachments/assets/64977054-f833-42e1-8f31-054f8137815d)
