### PR TITLE
Move to 6.0.2-0 prerelease

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -66,7 +66,7 @@ Here are the common scenarios in which we should run the `bump-version` command:
   - Upload the APK file downloaded from Bitrise and tested above
   - Add release notes
   - Submit for review/release
-- Once the release is accepted by both the stores run `yarn bump-version version prereleaase` on `dev`, commit the changes, then `git push --tags` to setup the next prerelease build versioning.
+- Once the release is accepted by both the stores run `yarn bump-version prepatch` and commit the changes to `dev` to setup the next patch version in a pre-release state (necessary for Apple to accept beta build after the current version is in production).
 - Open a new Milestone with the current pre-release version:
   - Look to `package.json#version` to get the new version, but leave off the `-0`
 

--- a/apps/mobile/android/app/build.gradle
+++ b/apps/mobile/android/app/build.gradle
@@ -90,8 +90,8 @@ android {
         applicationId "com.hylo.hyloandroid"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 297
-        versionName "6.0.1"
+        versionCode 298
+        versionName "6.0.2-0"
     }
     signingConfigs {
         debug {

--- a/apps/mobile/ios/HyloReactNative/Info.plist
+++ b/apps/mobile/ios/HyloReactNative/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.0.1</string>
+	<string>6.0.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -40,7 +40,7 @@
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>CFBundleURLIconFile</key>
-			<string></string>
+			<string />
 			<key>CFBundleURLName</key>
 			<string>hyloapp</string>
 			<key>CFBundleURLSchemes</key>
@@ -50,19 +50,19 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>10000</string>
+	<string>10001</string>
 	<key>FacebookAdvertiserIDCollectionEnabled</key>
-	<false/>
+	<false />
 	<key>FacebookAppID</key>
 	<string>$(FACEBOOK_APP_ID)</string>
 	<key>FacebookAutoLogAppEventsEnabled</key>
-	<false/>
+	<false />
 	<key>FacebookClientToken</key>
 	<string>$(FACEBOOK_CLIENT_TOKEN)</string>
 	<key>FacebookDisplayName</key>
 	<string>Hylo</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
+	<false />
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>fbapi</string>
@@ -71,13 +71,13 @@
 		<string>fbshareextension</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>
-	<true/>
+	<true />
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
-		<false/>
+		<false />
 		<key>NSAllowsLocalNetworking</key>
-		<true/>
+		<true />
 	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>Take photos to add to your posts</string>
@@ -134,6 +134,6 @@
 	<key>UIUserInterfaceStyle</key>
 	<string>Light</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
+	<false />
 </dict>
 </plist>

--- a/apps/mobile/ios/HyloReactNativeTests/Info.plist
+++ b/apps/mobile/ios/HyloReactNativeTests/Info.plist
@@ -15,10 +15,10 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.0.1</string>
+	<string>6.0.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>217</string>
+	<string>218</string>
 </dict>
 </plist>

--- a/apps/mobile/ios/OneSignalNotificationServiceExtension/Info.plist
+++ b/apps/mobile/ios/OneSignalNotificationServiceExtension/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.0.1</string>
+	<string>6.0.2</string>
 	<key>CFBundleVersion</key>
-	<string>217</string>
+	<string>218</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile",
-  "version": "6.0.1",
+  "version": "6.0.2-0",
   "private": true,
   "scripts": {
     "android": "adb reverse tcp:3001 tcp:3001 && adb reverse tcp:3000 tcp:3000 && react-native run-android",


### PR DESCRIPTION
Updates Mobile version to next pre-release version (6.0.2-0) as per Mobile README release instructions. Once a version is released Apple will reject any further submissions under that version number, so this allows builds to happen again. 

Base branch is https://github.com/Hylozoic/hylo/pull/521 which reverts issues introduced by #468 `@hylo/shared/DateTimeHelper` work which is was blocking successful builds of Mobile.

BitRise builds https://app.bitrise.io/build/6dec3223-cafe-4030-aa43-dc40e2acaa04 (Android) and https://app.bitrise.io/build/14b5a0e3-d4d0-4ac0-85a5-d86017452030 (iOS) build this branch against Production API to allow testing of Stream query changes, etc. 