### PR TITLE
493-mobile-group-context-fix

### DIFF
--- a/apps/mobile/src/components/ContextMenu/ContextMenu.js
+++ b/apps/mobile/src/components/ContextMenu/ContextMenu.js
@@ -195,10 +195,10 @@ function ContextWidgetActions ({ widget }) {
   }
 
   if (widget.type === 'setup') {
-    const settingsDetailsPath = `/groups/${currentGroup.slug}/settings/details`
+    const settingsDetailsPath = `/groups/${currentGroup.slug}/settings`
     return (
       <View className='mb-2'>
-        <ContextWidgetActionLink title='Settings' path={`/groups/${currentGroup.slug}/settings`} />
+        <ContextWidgetActionLink title='Settings' path={`/groups/${currentGroup.slug}/settings/index`} />
         <View>
           {!currentGroup.avatarUrl && (
             <ContextWidgetActionLink title='Add Avatar' path={settingsDetailsPath} />

--- a/apps/mobile/src/components/HyloWebView/HyloWebView.js
+++ b/apps/mobile/src/components/HyloWebView/HyloWebView.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useEffect, useMemo } from 'react'
+import React, { useCallback, useState } from 'react'
 import { useFocusEffect, useNavigation } from '@react-navigation/native'
 import Config from 'react-native-config'
 import useRouteParams from 'hooks/useRouteParams'

--- a/apps/mobile/src/hooks/useHandleCurrentGroup.js
+++ b/apps/mobile/src/hooks/useHandleCurrentGroup.js
@@ -1,5 +1,7 @@
 import { useCallback, useEffect } from 'react'
 import { useNavigation } from '@react-navigation/native'
+import { useMutation } from 'urql'
+import updateUserSettingsMutation from '@hylo/graphql/mutations/updateUserSettingsMutation'
 import { isStaticContext } from '@hylo/presenters/GroupPresenter'
 import useCurrentUser from '@hylo/hooks/useCurrentUser'
 import useCurrentGroup, { getLastViewedGroupSlug, useCurrentGroupStore } from '@hylo/hooks/useCurrentGroup'
@@ -82,6 +84,7 @@ export function useChangeToGroup () {
   const confirmAlert = useConfirmAlert()
   const { setCurrentGroupSlug, setNavigateHome } = useCurrentGroupStore()
   const [{ currentUser }] = useCurrentUser()
+  const [, updateUserSettings] = useMutation(updateUserSettingsMutation)
 
   const changeToGroup = useCallback((groupSlug, {
     confirm = false,
@@ -96,6 +99,7 @@ export function useChangeToGroup () {
       const goToGroup = () => {
         if (navigateHome) setNavigateHome(navigateHome)
         setCurrentGroupSlug(groupSlug)
+        updateUserSettings({ changes: { settings: { lastViewedAt: (new Date()).toISOString() } } })
       }
       if (confirm) {
         confirmAlert({

--- a/apps/mobile/src/hooks/useOpenURL.js
+++ b/apps/mobile/src/hooks/useOpenURL.js
@@ -29,7 +29,6 @@ export async function openURL (
     !staticPages.includes(linkingURL.pathname)
   ) {
     const linkingPath = linkingURL.pathname + linkingURL.search
-
     const stateForPath = getStateFromPath(linkingPath)
 
     if (stateForPath) {

--- a/apps/mobile/src/navigation/HomeNavigator.js
+++ b/apps/mobile/src/navigation/HomeNavigator.js
@@ -29,27 +29,7 @@ export default function HomeNavigator () {
   const navigatorProps = {
     screenOptions: {
       header: props => <TabStackHeader {...props} />,
-      headerMode: 'float',
-      transitionSpec: {
-        open: {
-          animation: 'spring',
-          stiffness: 1000,
-          damping: 500,
-          mass: 3,
-          overshootClamping: true,
-          restDisplacementThreshold: 0.01,
-          restSpeedThreshold: 0.01
-        },
-        close: {
-          animation: 'spring',
-          stiffness: 1000,
-          damping: 500,
-          mass: 3,
-          overshootClamping: true,
-          restDisplacementThreshold: 0.01,
-          restSpeedThreshold: 0.01
-        }
-      }
+      headerMode: 'float'
     }
   }
 

--- a/apps/mobile/src/navigation/headers/TabStackHeader.js
+++ b/apps/mobile/src/navigation/headers/TabStackHeader.js
@@ -79,6 +79,8 @@ export default function TabStackHeader ({
     options?.headerTitle
   ])
 
+  if (!currentGroup) return null
+
   return <Header {...props} {...otherProps} />
 }
 

--- a/apps/mobile/src/navigation/linking/index.js
+++ b/apps/mobile/src/navigation/linking/index.js
@@ -131,8 +131,7 @@ export const routingConfig = {
   '/:context(groups)/:groupSlug/topics/:topicName/post/:id':              `${AUTH_ROOT_SCREEN_NAME}/Drawer/Tabs/Home Tab/Chat Room`,
   '/:context(groups)/:groupSlug/topics':                                  `${AUTH_ROOT_SCREEN_NAME}/Drawer/Tabs/Home Tab/Web View`,
   '/:context(groups)/:groupSlug/custom/:customViewId':                    `${AUTH_ROOT_SCREEN_NAME}/Drawer/Tabs/Home Tab/Stream`,
-  '/:context(groups)/:groupSlug/settings/:settingsArea':                  `${AUTH_ROOT_SCREEN_NAME}/Drawer/Tabs/Home Tab/Group Settings`,
-  '/:context(groups)/:groupSlug/settings':                                `${AUTH_ROOT_SCREEN_NAME}/Drawer/Tabs/Home Tab/Group Settings`,
+  '/:context(groups)/:groupSlug/settings/:settingsArea?':                 `${AUTH_ROOT_SCREEN_NAME}/Drawer/Tabs/Home Tab/Group Settings`,
   // TODO:  Routing - potentially group these
   '/:context(groups)/:groupSlug/stream':                                  `${AUTH_ROOT_SCREEN_NAME}/Drawer/Tabs/Home Tab/Stream`,
   '/:context(groups)/:groupSlug/:streamType(moderation)':                 `${AUTH_ROOT_SCREEN_NAME}/Drawer/Tabs/Home Tab/Moderation`,

--- a/apps/mobile/src/screens/ChatRoomWebView/ChatRoomWebView.js
+++ b/apps/mobile/src/screens/ChatRoomWebView/ChatRoomWebView.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 import useCurrentGroup from '@hylo/hooks/useCurrentGroup'
 import useRouteParams from 'hooks/useRouteParams'
 import HyloWebView from 'components/HyloWebView'
@@ -8,7 +8,7 @@ export const DEFAULT_CHAT_TOPIC = 'home'
 
 export default function ChatRoomWebView () {
   const [{ currentGroup, fetching }] = useCurrentGroup()
-  const { topicName: routeTopicName, originalLinkingPath } = useRouteParams()
+  const { topicName: routeTopicName } = useRouteParams()
   const topicName = routeTopicName || DEFAULT_CHAT_TOPIC
   const path = `/groups/${currentGroup?.slug}/chat/${topicName}`
 

--- a/apps/mobile/src/screens/ChatRoomWebView/ChatRoomWebView.js
+++ b/apps/mobile/src/screens/ChatRoomWebView/ChatRoomWebView.js
@@ -1,22 +1,22 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import useCurrentGroup from '@hylo/hooks/useCurrentGroup'
 import useRouteParams from 'hooks/useRouteParams'
 import HyloWebView from 'components/HyloWebView'
 import KeyboardFriendlyView from 'components/KeyboardFriendlyView'
 
+export const DEFAULT_CHAT_TOPIC = 'home'
+
 export default function ChatRoomWebView () {
   const [{ currentGroup, fetching }] = useCurrentGroup()
   const { topicName: routeTopicName, originalLinkingPath } = useRouteParams()
-  const topicName = routeTopicName || 'home'
-  const path = originalLinkingPath || `/groups/${currentGroup?.slug}/chat/${topicName}`
-  const handledWebRoutes = [
-    `/groups/${currentGroup?.slug}/chat/:topicName`
-  ]
-  if (fetching) return null
+  const topicName = routeTopicName || DEFAULT_CHAT_TOPIC
+  const path = `/groups/${currentGroup?.slug}/chat/${topicName}`
+
+  if (!currentGroup?.slug || fetching) return null
 
   return (
     <KeyboardFriendlyView style={{ flex: 1 }}>
-      <HyloWebView handledWebRoutes={handledWebRoutes} path={path} />
+      <HyloWebView path={path} />
     </KeyboardFriendlyView>
   )
 }

--- a/apps/mobile/src/screens/GroupSettingsWebView/GroupSettingsWebView.js
+++ b/apps/mobile/src/screens/GroupSettingsWebView/GroupSettingsWebView.js
@@ -1,27 +1,18 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback } from 'react'
 import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import { useFocusEffect, useNavigation } from '@react-navigation/native'
 import useGroup from '@hylo/hooks/useGroup'
 import useRouteParams from 'hooks/useRouteParams'
-import HyloWebView from 'components/HyloWebView'
+import HyloWebView from 'components/HyloWebView/HyloWebView'
 import { amaranth, capeCod, rhino40, rhino80, twBackground } from 'style/colors'
 
 export default function GroupSettingsWebView () {
   const navigation = useNavigation()
-  const webViewRef = useRef()
-  const { groupSlug, originalLinkingPath, settingsArea: routeSettingsArea } = useRouteParams()
+  const { groupSlug, settingsArea: routeSettingsArea, originalLinkingPath, } = useRouteParams()
   const [, queryGroup] = useGroup({ groupSlug, useQueryArgs: { requestPolicy: 'network-only', pause: true } })
-  const [selectedSettingsArea, setSelectedSettingsArea] = useState(routeSettingsArea)
-
-  useEffect(() => {
-    setSelectedSettingsArea(routeSettingsArea)
-  }, [routeSettingsArea])
-
-  useEffect(() => {
-    navigation.setOptions({
-      headerLeftOnPress: (!routeSettingsArea && selectedSettingsArea) && (() => setSelectedSettingsArea())
-    })
-  }, [selectedSettingsArea])
+  const goToSettingsArea = useCallback(settingsArea => {
+    navigation.push('Group Settings', { originalLinkingPath: `/groups/${groupSlug}/settings/${settingsArea}` })
+  }, [groupSlug])
 
   // Always re-queries group onBlur
   useFocusEffect(
@@ -32,28 +23,8 @@ export default function GroupSettingsWebView () {
     }, [])
   )
 
-  const handleNavigationStateChange = useCallback(({ url }) => {
-    // // Temporary sorta fix for Group delete which reloads the page
-    // if (url.match(/\/all/)) {
-    //   // TODO: After deleting a group on Web the user used to be forwarded to /all. Needs to be confirm that this is still
-    //   // the case, and tested if this re-query of currentUser adequately updates the list of groups for the user. It should.
-    //   // queryCurrentUser is provisional and replacing what as a RNRestart() call, which we should basically never do.
-    //   queryCurrentUser()
-    //   return false
-    // }
-    if (!url.match(/\/groups\/([^/]+)settings/)) {
-      webViewRef.current?.goBack()
-      return false
-    }
-  })
-
-  const path = useMemo(() => selectedSettingsArea
-    ? `/groups/${groupSlug}/settings/${selectedSettingsArea === 'details' ? '' : selectedSettingsArea}`
-    : originalLinkingPath
-  , [selectedSettingsArea, originalLinkingPath])
-
   const settingsOptions = [
-    { settingsArea: 'details', label: 'Group Details' },
+    { settingsArea: '', label: 'Group Details' },
     { settingsArea: 'agreements', label: 'Agreements' },
     { settingsArea: 'welcome', label: 'Welcome Page' },
     { settingsArea: 'responsibilities', label: 'Responsibilities' },
@@ -67,30 +38,25 @@ export default function GroupSettingsWebView () {
     { settingsArea: 'delete', label: 'Delete', style: { color: amaranth } }
   ]
 
+  if (routeSettingsArea !== 'index') {
+    return (
+      <HyloWebView path={originalLinkingPath} />
+    )
+  }
+
   return (
     <View style={[styles.container]}>
-      {selectedSettingsArea
-        ? (
-          <HyloWebView
-            ref={webViewRef}
-            key={path}
-            path={path}
-            onNavigationStateChange={handleNavigationStateChange}
-          />
-          )
-        : (
-          <ScrollView contentContainerStyle={styles.menu}>
-            {settingsOptions.map(({ settingsArea, label, style }) => (
-              <TouchableOpacity
-                key={settingsArea}
-                style={styles.menuItem}
-                onPress={() => setSelectedSettingsArea(settingsArea)}
-              >
-                <Text style={[styles.menuText, style]}>{label}</Text>
-              </TouchableOpacity>
-            ))}
-          </ScrollView>
-          )}
+      <ScrollView contentContainerStyle={styles.menu}>
+        {settingsOptions.map(({ settingsArea, label, style }) => (
+          <TouchableOpacity
+            key={settingsArea}
+            style={styles.menuItem}
+            onPress={() => goToSettingsArea(settingsArea)}
+          >
+            <Text style={[styles.menuText, style]}>{label}</Text>
+          </TouchableOpacity>
+        ))}
+      </ScrollView>
     </View>
   )
 }

--- a/apps/mobile/src/screens/GroupSettingsWebView/GroupSettingsWebView.js
+++ b/apps/mobile/src/screens/GroupSettingsWebView/GroupSettingsWebView.js
@@ -3,7 +3,7 @@ import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-nati
 import { useFocusEffect, useNavigation } from '@react-navigation/native'
 import useGroup from '@hylo/hooks/useGroup'
 import useRouteParams from 'hooks/useRouteParams'
-import HyloWebView from 'components/HyloWebView/HyloWebView'
+import HyloWebView from 'components/HyloWebView'
 import { amaranth, capeCod, rhino40, rhino80, twBackground } from 'style/colors'
 
 export default function GroupSettingsWebView () {


### PR DESCRIPTION
- Fixes #493: ChatWebView was always using originalLinkingPath even when currentGroup.slug changed. Now it re-constructs path using currentGroup and the parsed path params
- Updates membership lastViewedAt on change to group, which seemed to be currently relying upon the update within WebView Chat
- Simplifies some HyloWebView implementation details for "handled routes" 
- Fixes currentGroup switch double-nav event (https://github.com/Hylozoic/hylo/issues/435 / https://github.com/Hylozoic/hylo/issues/528)
- Update GroupSettingsWebView to also not rely exclusively on originalLinkingPath to fix the same issue: currently when in group settings and then linking to another screen in another group, the settings screen will not update to the newly selected current group
