### PR TITLE
580 dates off by one in firefox

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -68,6 +68,7 @@
     "@dnd-kit/modifiers": "8.0.0",
     "@dnd-kit/sortable": "^7.0.2",
     "@emoji-mart/react": "^1.1.1",
+    "@formatjs/intl-locale": "^4.2.11",
     "@hylo/contexts": "workspace:*",
     "@hylo/graphql": "workspace:*",
     "@hylo/hooks": "workspace:*",

--- a/apps/web/src/components/Calendar/calendar-util.tsx
+++ b/apps/web/src/components/Calendar/calendar-util.tsx
@@ -68,7 +68,7 @@ export const inWeek = (
   const _dt2 = DateTime.fromJSDate(dt2).setLocale(getLocaleAsString())
   const _dt3 = DateTime.fromJSDate(dt3).setLocale(getLocaleAsString())
   const weekStart = _dt2.startOf('week', { useLocaleWeeks: true })
-  const weekEnd = _dt2.endOf('week', { useLocaleWeeks: true }).plus({ days: 1 })
+  const weekEnd = _dt2.endOf('week', { useLocaleWeeks: true })
   return _dt1 < weekEnd && weekStart <= _dt3
 }
 

--- a/apps/web/src/config/index.js
+++ b/apps/web/src/config/index.js
@@ -1,14 +1,7 @@
 import { once } from 'lodash'
 
 // add polyfill due to Firefox off-by-one bug https://github.com/moment/luxon/issues/1563
-import {shouldPolyfill} from '@formatjs/intl-locale/should-polyfill'
-async function polyfill() {
-  // skip import platform already supports Intl.Locale
-  if (shouldPolyfill()) {
-    await import('@formatjs/intl-locale/polyfill')
-  }
-}
-polyfill()
+import('@formatjs/intl-locale/polyfill-force')
 
 export const environment = import.meta.env.NODE_ENV || 'development'
 export const isTest = environment === 'test'

--- a/apps/web/src/config/index.js
+++ b/apps/web/src/config/index.js
@@ -1,4 +1,6 @@
 import { once } from 'lodash'
+
+// add polyfill due to Firefox off-by-one bug https://github.com/moment/luxon/issues/1563
 import {shouldPolyfill} from '@formatjs/intl-locale/should-polyfill'
 async function polyfill() {
   // This platform already supports Intl.Locale

--- a/apps/web/src/config/index.js
+++ b/apps/web/src/config/index.js
@@ -3,12 +3,10 @@ import { once } from 'lodash'
 // add polyfill due to Firefox off-by-one bug https://github.com/moment/luxon/issues/1563
 import {shouldPolyfill} from '@formatjs/intl-locale/should-polyfill'
 async function polyfill() {
-  // This platform already supports Intl.Locale
+  // skip import platform already supports Intl.Locale
   if (shouldPolyfill()) {
     await import('@formatjs/intl-locale/polyfill')
   }
-  // Alternatively, force the polyfill regardless of support
-  await import('@formatjs/intl-locale/polyfill-force')
 }
 polyfill()
 

--- a/apps/web/src/config/index.js
+++ b/apps/web/src/config/index.js
@@ -1,4 +1,14 @@
 import { once } from 'lodash'
+import {shouldPolyfill} from '@formatjs/intl-locale/should-polyfill'
+async function polyfill() {
+  // This platform already supports Intl.Locale
+  if (shouldPolyfill()) {
+    await import('@formatjs/intl-locale/polyfill')
+  }
+  // Alternatively, force the polyfill regardless of support
+  await import('@formatjs/intl-locale/polyfill-force')
+}
+polyfill()
 
 export const environment = import.meta.env.NODE_ENV || 'development'
 export const isTest = environment === 'test'

--- a/yarn.lock
+++ b/yarn.lock
@@ -3286,6 +3286,67 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@formatjs/ecma402-abstract@npm:2.3.4":
+  version: 2.3.4
+  resolution: "@formatjs/ecma402-abstract@npm:2.3.4"
+  dependencies:
+    "@formatjs/fast-memoize": "npm:2.2.7"
+    "@formatjs/intl-localematcher": "npm:0.6.1"
+    decimal.js: "npm:^10.4.3"
+    tslib: "npm:^2.8.0"
+  checksum: 10/573971ffc291096a4b9fcc80b4708124e89bf2e3ac50e0f78b41eb797e9aa1b842f4dc3665e4467a853c738386821769d9e40408a1d25bc73323a1f057a16cf2
+  languageName: node
+  linkType: hard
+
+"@formatjs/fast-memoize@npm:2.2.7":
+  version: 2.2.7
+  resolution: "@formatjs/fast-memoize@npm:2.2.7"
+  dependencies:
+    tslib: "npm:^2.8.0"
+  checksum: 10/e7e6efc677d63a13d99a854305db471b69f64cbfebdcb6dbe507dab9aa7eaae482ca5de86f343c856ca0a2c8f251672bd1f37c572ce14af602c0287378097d43
+  languageName: node
+  linkType: hard
+
+"@formatjs/intl-enumerator@npm:1.8.10":
+  version: 1.8.10
+  resolution: "@formatjs/intl-enumerator@npm:1.8.10"
+  dependencies:
+    "@formatjs/ecma402-abstract": "npm:2.3.4"
+    tslib: "npm:^2.8.0"
+  checksum: 10/9e0e762143248bf91e174d3abc15261b47ac7294632d26797cf5b001707aa68ca2deeb05c95f7308aa2cffa46d61b0fac46306dea722ab210dfa012990743798
+  languageName: node
+  linkType: hard
+
+"@formatjs/intl-getcanonicallocales@npm:2.5.5":
+  version: 2.5.5
+  resolution: "@formatjs/intl-getcanonicallocales@npm:2.5.5"
+  dependencies:
+    tslib: "npm:^2.8.0"
+  checksum: 10/2a32202765c9a4f16fc36f4e4afca7fd5f4f35885ad2ca671352a7bba1a19d5ec81933d52ab1855c8570e73247213739d9d2d95d2438bd9f02a1f0db7cb9b8a9
+  languageName: node
+  linkType: hard
+
+"@formatjs/intl-locale@npm:^4.2.11":
+  version: 4.2.11
+  resolution: "@formatjs/intl-locale@npm:4.2.11"
+  dependencies:
+    "@formatjs/ecma402-abstract": "npm:2.3.4"
+    "@formatjs/intl-enumerator": "npm:1.8.10"
+    "@formatjs/intl-getcanonicallocales": "npm:2.5.5"
+    tslib: "npm:^2.8.0"
+  checksum: 10/8746af66ebd5284f189c83e0d59a4d781490ce3eadaab284bf96c4240eaf8b9422130a94a842a1ab12fa14bb2cdf02e9f78ac3b9cf955156fafeffab9d73d7a2
+  languageName: node
+  linkType: hard
+
+"@formatjs/intl-localematcher@npm:0.6.1":
+  version: 0.6.1
+  resolution: "@formatjs/intl-localematcher@npm:0.6.1"
+  dependencies:
+    tslib: "npm:^2.8.0"
+  checksum: 10/c7b3bc8395d18670677f207b2fd107561fff5d6394a9b4273c29e0bea920300ec3a2eefead600ebb7761c04a770cada28f78ac059f84d00520bfb57a9db36998
+  languageName: node
+  linkType: hard
+
 "@formidable-webview/webshell@npm:^2.6.0":
   version: 2.6.0
   resolution: "@formidable-webview/webshell@npm:2.6.0"
@@ -35026,7 +35087,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:2.8.1, tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.5.0, tslib@npm:^2.6.3, tslib@npm:^2.8.1":
+"tslib@npm:2.8.1, tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.5.0, tslib@npm:^2.6.3, tslib@npm:^2.8.0, tslib@npm:^2.8.1":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10/3e2e043d5c2316461cb54e5c7fe02c30ef6dccb3384717ca22ae5c6b5bc95232a6241df19c622d9c73b809bea33b187f6dbc73030963e29950c2141bc32a79f7
@@ -36391,6 +36452,7 @@ __metadata:
     "@eslint/eslintrc": "npm:^3.1.0"
     "@eslint/js": "npm:^9.14.0"
     "@faker-js/faker": "npm:^6.0.0-alpha.5"
+    "@formatjs/intl-locale": "npm:^4.2.11"
     "@hylo/contexts": "workspace:*"
     "@hylo/graphql": "workspace:*"
     "@hylo/hooks": "workspace:*"


### PR DESCRIPTION
closes #580 

Two commits:
* first one closes the "off by one" issue
* second one fixes a subtle bug I noticed in calendar week view

@tibet @lorenjohnson : I notice that DateHelper util file is not in the dev branch. Was there a problem with it or was that PR never merged? I recall that Loren had some concerns with it.