### PR TITLE
Load #topics much faster in posts

### DIFF
--- a/apps/backend/api/graphql/filters.js
+++ b/apps/backend/api/graphql/filters.js
@@ -61,6 +61,7 @@ export const groupFilter = userId => relation => {
 export function groupTopicFilter (userId, {
   autocomplete,
   groupId,
+  groupIds,
   isDefault,
   subscribed,
   visibility
@@ -69,6 +70,9 @@ export function groupTopicFilter (userId, {
     q.distinct('groups_tags.tag_id')
     if (groupId) {
       q.where('groups_tags.group_id', groupId)
+    }
+    if (groupIds) {
+      q.whereIn('groups_tags.group_id', groupIds)
     }
 
     if (autocomplete) {

--- a/apps/backend/api/graphql/makeModels.js
+++ b/apps/backend/api/graphql/makeModels.js
@@ -542,11 +542,12 @@ export default function makeModels (userId, isAdmin, apiClient) {
           groupTags: {
             querySet: true,
             alias: 'groupTopics',
-            filter: (relation, { autocomplete, subscribed, groupId }) =>
+            filter: (relation, { autocomplete, subscribed, groupId, groupIds }) =>
               relation.query(groupTopicFilter(userId, {
                 autocomplete,
                 subscribed,
-                groupId: relation.relatedData.parentId || groupId
+                groupId: relation.relatedData.parentId || groupId,
+                groupIds
               }))
           }
         },
@@ -1138,10 +1139,11 @@ export default function makeModels (userId, isAdmin, apiClient) {
         groupTags: {
           alias: 'groupTopics',
           querySet: true,
-          filter: (relation, { autocomplete, subscribed, isDefault, visibility, groupId }) =>
+          filter: (relation, { autocomplete, subscribed, isDefault, visibility, groupId, groupIds }) =>
             relation.query(groupTopicFilter(userId, {
               autocomplete,
               groupId,
+              groupIds,
               isDefault,
               subscribed,
               visibility
@@ -1149,8 +1151,8 @@ export default function makeModels (userId, isAdmin, apiClient) {
             )
         }
       }],
-      fetchMany: ({ groupSlug, name, isDefault, visibility, autocomplete, first, offset = 0, sortBy }) =>
-        searchQuerySet('tags', { userId, groupSlug, name, autocomplete, isDefault, visibility, limit: first, offset, sort: sortBy })
+      fetchMany: ({ groupSlug, groupIds, name, isDefault, visibility, autocomplete, first, offset = 0, sortBy }) =>
+        searchQuerySet('tags', { userId, groupSlug, groupIds, name, autocomplete, isDefault, visibility, limit: first, offset, sort: sortBy })
     },
 
     TopicFollow: {

--- a/apps/backend/api/graphql/schema.graphql
+++ b/apps/backend/api/graphql/schema.graphql
@@ -115,8 +115,10 @@ type Query {
     autocomplete: String,
     # Int of GroupTopics to return
     first: Int,
-    # filter by group id
-    groupId: ID
+    # filter by group id XXX: DEPRECATED use groupIds instead
+    groupId: ID,
+    # filter by group ids
+    groupIds: [ID],
     # If true only return topics that are set to be a default topic in a group that the current logged in user is a member of
     isDefault: Boolean,
     # For pagination, start loading GroupTopics after this offset
@@ -298,6 +300,8 @@ type Query {
     autocomplete: String,
     # Number of topics to return
     first: Int,
+    # Only return topics used in these groups by group ID
+    groupIds: [ID],
     # Only return topics used in this Group by URL slug
     groupSlug: String,
     # If true only return topics that are set to be a default topic in a group that the current logged in user is a member of

--- a/apps/backend/api/services/Search.js
+++ b/apps/backend/api/services/Search.js
@@ -109,6 +109,10 @@ module.exports = {
         q.where('groups.slug', '=', opts.groupSlug)
       }
 
+      if (opts.groupIds) {
+        q.whereIn('groups.id', opts.groupIds)
+      }
+
       if (opts.name) {
         q.where('tags.name', opts.name)
       }

--- a/apps/web/src/components/HyloEditor/extensions/TopicMentions.js
+++ b/apps/web/src/components/HyloEditor/extensions/TopicMentions.js
@@ -51,12 +51,11 @@ export const TopicMentions = ({ groupIds, maxSuggestions, onSelection, suggestio
             maxItems: maxSuggestions
           }).graphql
           const matchedTopics = await queryHyloAPI(findTopicsGraphql)
-
-          const results = matchedTopics?.data.groupTopics.items
+          const results = matchedTopics?.data.topics.items
             .map(t => ({
-              id: t.topic.name,
-              label: `#${t.topic.name}`,
-              suggestionLabel: t.topic.name
+              id: t.name,
+              label: `#${t.name}`,
+              suggestionLabel: t.name
             }))
 
           if (query?.trim().length > 2 && results) {

--- a/apps/web/src/components/TopicSelector/TopicSelector.js
+++ b/apps/web/src/components/TopicSelector/TopicSelector.js
@@ -71,8 +71,8 @@ function TopicSelector (props) {
 
     if (selected.length >= MAX_TOPICS || isEmpty(input)) return []
 
-    const response = await dispatch(findTopics({ autocomplete: input, groupSlug: slug }))
-    const topicResults = response.payload.getData().items.map(get('topic'))
+    const response = await dispatch(findTopics({ autocomplete: input, groupSlug: slug, includeCounts: true }))
+    const topicResults = response.payload.getData().items
     const sortedTopicResults = orderBy(
       [t => t.name === input ? -1 : 1, 'followersTotal', 'postsTotal'],
       ['asc', 'desc', 'desc'],

--- a/apps/web/src/routes/AllView/AllView.jsx
+++ b/apps/web/src/routes/AllView/AllView.jsx
@@ -499,11 +499,11 @@ function ItemSelector ({ addChoice, group, selectedItem, setSelectedItem, widget
       try {
         const response = await dispatch(findTopics({
           autocomplete: debouncedSearch,
-          groupId: group.id,
+          groupIds: [group.id],
           maxItems: 10
         }))
-        const result = response?.payload?.data?.groupTopics?.items?.map(item => item.topic)
-        if (debouncedSearch.length > 0) result.push({ name: debouncedSearch, id: 'create' })
+        const result = response?.payload?.data?.topics?.items
+        if (debouncedSearch.length > 0 && !result.find(t => t.name === debouncedSearch)) result.push({ name: debouncedSearch, id: 'create' })
         setItems(result || [])
       } catch (error) {
         console.error('Error fetching topics:', error)

--- a/apps/web/src/store/actions/findTopics.js
+++ b/apps/web/src/store/actions/findTopics.js
@@ -2,24 +2,25 @@ import { get } from 'lodash/fp'
 import gql from 'graphql-tag'
 import { FIND_TOPICS } from 'store/constants'
 
-export default function findTopics ({ autocomplete, maxItems = 7, groupId, groupSlug }) {
+export default function findTopics ({ autocomplete, maxItems = 7, groupIds, groupSlug, includeCounts = false }) {
   return {
     type: FIND_TOPICS,
     graphql: {
       query: gql`
-        query FindTopicsQuery ($autocomplete: String, $maxItems: Int, $groupId: ID, $groupSlug: String) {
-          groupTopics(autocomplete: $autocomplete, first: $maxItems, groupId: $groupId) {
+        query FindTopicsQuery ($autocomplete: String, $maxItems: Int, $groupSlug: String, $groupIds: [ID]) {
+          topics(autocomplete: $autocomplete, first: $maxItems, groupSlug: $groupSlug, groupIds: $groupIds) {
             items {
-              topic {
-                id
-                name
+              id
+              name
+              ${includeCounts
+                ? `
                 followersTotal(
                   groupSlug: $groupSlug
                 )
                 postsTotal(
                   groupSlug: $groupSlug
-                )
-              }
+                )`
+                : ''}
             }
           }
         }
@@ -27,18 +28,16 @@ export default function findTopics ({ autocomplete, maxItems = 7, groupId, group
       variables: {
         autocomplete,
         maxItems,
-        groupId,
+        groupIds,
         groupSlug
       }
     },
     meta: {
       extractModel: {
-        getRoot: collectTopics,
+        getRoot: get('topics'),
         modelName: 'Topic',
         append: true
       }
     }
   }
 }
-
-const collectTopics = results => results.groupTopics.items.map(get('topic'))


### PR DESCRIPTION
 Make the topic selector much faster
    
    Also don't show duplicate create option in the add Chat Room selector when typing in an existing topic in the group.
    
    Fixes https://github.com/Hylozoic/hylo/issues/556