### PR TITLE
Try to fix crashing error when notification comes in while app is in …

### DIFF
--- a/apps/mobile/index.js
+++ b/apps/mobile/index.js
@@ -118,9 +118,9 @@ export default function App () {
       // OneSignal.Debug.setLogLevel(LogLevel.Verbose);
 
       // Method for handling notifications received while app in foreground
-      const foregroundWillDisplayHandler = notIfReceivedEvent => {
-        // Complete with null means don't show a notification.
-        notIfReceivedEvent.complete()
+      const foregroundWillDisplayHandler = event => {
+        event.preventDefault()
+        console.log('foreground notification received:', event.notification)
       }
       OneSignal.Notifications.addEventListener('foregroundWillDisplay', foregroundWillDisplayHandler)
 


### PR DESCRIPTION
…focus

Havent tested because still not setup too. solution comes from https://stackoverflow.com/questions/41183885/how-to-prevent-alert-with-incoming-onesignal-notification