### PR TITLE
657 add groups to subscriptions

### DIFF
--- a/apps/backend/api/graphql/makeSchema.js
+++ b/apps/backend/api/graphql/makeSchema.js
@@ -186,6 +186,7 @@ export default async function makeSchema ({ req }) {
           // in makeModels, and there is apparently no other way to infer the types, so the
           // correct type is set on makeModelsType by the subscription resolver to be used here
           if (data?.makeModelsType) return data.makeModelsType
+
           const foundType = getTypeForInstance(data, models)
           if (foundType) return foundType
           throw new Error(`Unable to determine GraphQL type for instance: ${data}`)
@@ -314,7 +315,7 @@ export function makeMutations ({ fetchOne }) {
     // available between auth'd and non-auth'd sessions
     ...makePublicMutations({ fetchOne }),
 
-    acceptGroupRelationshipInvite: (root, { groupRelationshipInviteId }, context) => acceptGroupRelationshipInvite(context.currentUserId, groupRelationshipInviteId),
+    acceptGroupRelationshipInvite: (root, { groupRelationshipInviteId }, context) => acceptGroupRelationshipInvite(context.currentUserId, groupRelationshipInviteId, context),
 
     acceptJoinRequest: (root, { joinRequestId }, context) => acceptJoinRequest(context.currentUserId, joinRequestId),
 
@@ -322,7 +323,7 @@ export function makeMutations ({ fetchOne }) {
 
     addGroupRole: (root, { groupId, color, name, description, emoji }, context) => addGroupRole({ userId: context.currentUserId, groupId, color, name, description, emoji }),
 
-    addModerator: (root, { personId, groupId }, context) => addModerator(context.currentUserId, personId, groupId),
+    addModerator: (root, { personId, groupId }, context) => addModerator(context.currentUserId, personId, groupId, context),
 
     addPeopleToProjectRole: (root, { peopleIds, projectRoleId }, context) => addPeopleToProjectRole(context.currentUserId, peopleIds, projectRoleId),
 
@@ -382,7 +383,7 @@ export function makeMutations ({ fetchOne }) {
 
     createZapierTrigger: (root, { groupIds, targetUrl, type, params }, context) => createZapierTrigger(context.currentUserId, groupIds, targetUrl, type, params),
 
-    joinGroup: (root, { groupId, questionAnswers }, context) => joinGroup(groupId, context.currentUserId, questionAnswers),
+    joinGroup: (root, { groupId, questionAnswers }, context) => joinGroup(groupId, context.currentUserId, questionAnswers, context),
 
     joinProject: (root, { id }, context) => joinProject(id, context.currentUserId),
 
@@ -398,7 +399,7 @@ export function makeMutations ({ fetchOne }) {
 
     deleteGroup: (root, { id }, context) => deleteGroup(context.currentUserId, id),
 
-    deleteGroupRelationship: (root, { parentId, childId }, context) => deleteGroupRelationship(context.currentUserId, parentId, childId),
+    deleteGroupRelationship: (root, { parentId, childId }, context) => deleteGroupRelationship(context.currentUserId, parentId, childId, context),
 
     deleteGroupResponsibility: (root, { responsibilityId, groupId }, context) => deleteGroupResponsibility({ userId: context.currentUserId, responsibilityId, groupId }),
 
@@ -475,9 +476,9 @@ export function makeMutations ({ fetchOne }) {
 
     removeWidgetFromMenu: (root, { contextWidgetId, groupId }, context) => removeWidgetFromMenu({ userId: context.currentUserId, contextWidgetId, groupId }),
 
-    removeMember: (root, { personId, groupId }, context) => removeMember(context.currentUserId, personId, groupId),
+    removeMember: (root, { personId, groupId }, context) => removeMember(context.currentUserId, personId, groupId, context),
 
-    removeModerator: (root, { personId, groupId, isRemoveFromGroup }, context) => removeModerator(context.currentUserId, personId, groupId, isRemoveFromGroup),
+    removeModerator: (root, { personId, groupId, isRemoveFromGroup }, context) => removeModerator(context.currentUserId, personId, groupId, isRemoveFromGroup, context),
 
     removePost: (root, { postId, groupId, slug }, context) => removePost(context.currentUserId, postId, groupId || slug),
 
@@ -530,7 +531,7 @@ export function makeMutations ({ fetchOne }) {
     updateGroupRole: (root, { groupRoleId, color, name, description, emoji, active, groupId }, context) =>
       updateGroupRole({ userId: context.currentUserId, groupRoleId, color, name, description, emoji, active, groupId }),
 
-    updateGroupSettings: (root, { id, changes }, context) => updateGroup(context.currentUserId, id, changes),
+    updateGroupSettings: (root, { id, changes }, context) => updateGroup(context.currentUserId, id, changes, context),
 
     updateGroupTopic: (root, { id, data }, context) => updateGroupTopic(id, data),
 
@@ -594,15 +595,4 @@ export function getTypeForInstance (instance, models) {
   }
 
   return modelToTypeMap[instance.tableName]
-}
-
-function logError (error) {
-  console.error(error.stack)
-
-  return {
-    message: error.message,
-    locations: error.locations,
-    stack: error.stack,
-    path: error.path
-  }
 }

--- a/apps/backend/api/graphql/makeSubscriptions.js
+++ b/apps/backend/api/graphql/makeSubscriptions.js
@@ -45,7 +45,7 @@ export default function makeSubscriptions () {
         context.pubSub.subscribe(
           messageThreadId
             ? `peopleTyping:messageThreadId:${messageThreadId}`
-            : postId 
+            : postId
               ? `peopleTyping:postId:${postId}`
               : `peopleTyping:commentId:${commentId}`
         ),
@@ -74,6 +74,54 @@ export default function makeSubscriptions () {
         }
         if (payload?.notification) {
           return new Notification(payload.notification)
+        }
+      }
+    },
+
+    groupUpdates: {
+      subscribe: (parent, args, context) => pipe(
+        context.pubSub.subscribe(`groupUpdates:${context.currentUserId}`),
+        withDontSendToCreator({ context })
+      ),
+      resolve: (payload) => {
+        if (payload?.group) {
+          return new Group(payload.group)
+        }
+      }
+    },
+
+    groupMembershipUpdates: {
+      subscribe: (parent, args, context) => pipe(
+        context.pubSub.subscribe(`groupMembershipUpdates:${context.currentUserId}`),
+        withDontSendToCreator({ context })
+      ),
+      resolve: (payload) => {
+        if (payload?.groupMembershipUpdate) {
+          return {
+            group: new Group(payload.groupMembershipUpdate.group),
+            member: new User(payload.groupMembershipUpdate.member),
+            action: payload.groupMembershipUpdate.action,
+            role: payload.groupMembershipUpdate.role,
+            makeModelsType: 'GroupMembershipUpdate'
+          }
+        }
+      }
+    },
+
+    groupRelationshipUpdates: {
+      subscribe: (parent, args, context) => pipe(
+        context.pubSub.subscribe(`groupRelationshipUpdates:${context.currentUserId}`),
+        withDontSendToCreator({ context })
+      ),
+      resolve: (payload) => {
+        if (payload?.groupRelationshipUpdate) {
+          return {
+            parentGroup: new Group(payload.groupRelationshipUpdate.parentGroup),
+            childGroup: new Group(payload.groupRelationshipUpdate.childGroup),
+            action: payload.groupRelationshipUpdate.action,
+            relationship: payload.groupRelationshipUpdate.relationship ? new GroupRelationship(payload.groupRelationshipUpdate.relationship) : null,
+            makeModelsType: 'GroupRelationshipUpdate'
+          }
         }
       }
     }

--- a/apps/backend/api/graphql/mutations/group.js
+++ b/apps/backend/api/graphql/mutations/group.js
@@ -2,6 +2,12 @@ import { GraphQLError } from 'graphql'
 import GroupService from '../../services/GroupService'
 import convertGraphqlData from './convertGraphqlData'
 import underlyingDeleteGroupTopic from '../../models/group/deleteGroupTopic'
+import {
+  publishGroupUpdate,
+  publishGroupMembershipUpdate,
+  publishGroupRelationshipUpdate,
+  publishAsync
+} from '../../../lib/groupSubscriptionPublisher'
 
 // Util function
 async function getStewardedGroup (userId, groupId, additionalResponsibility = '', opts = {}) {
@@ -20,9 +26,18 @@ async function getStewardedGroup (userId, groupId, additionalResponsibility = ''
 
 // Group Mutations
 
-export async function addModerator (userId, personId, groupId) {
+export async function addModerator (userId, personId, groupId, context) {
   const group = await getStewardedGroup(userId, groupId, Responsibility.constants.RESP_ADMINISTRATION)
+  const person = await User.find(personId)
   await GroupMembership.setModeratorRole(personId, group)
+
+  // Publish group membership update to all group members (non-blocking)
+  publishAsync(publishGroupMembershipUpdate, context, group, {
+    group,
+    member: person,
+    action: 'moderator_added'
+  })
+
   return group
 }
 
@@ -46,7 +61,7 @@ export async function deleteGroupTopic (userId, groupTopicId) {
   return { success: true }
 }
 
-export async function deleteGroupRelationship (userId, parentId, childId) {
+export async function deleteGroupRelationship (userId, parentId, childId, context) {
   const groupRelationship = await GroupRelationship.forPair(parentId, childId).fetch()
   if (!groupRelationship) {
     return { success: true }
@@ -62,13 +77,24 @@ export async function deleteGroupRelationship (userId, parentId, childId) {
   if (childGroup || parentGroup) {
     // the logged in user is a steward of one of the groups and so can delete the relationship
     await groupRelationship.save({ active: false })
+
+    // Publish group relationship updates to all members of both groups (non-blocking)
+    const parentGroupObj = await Group.find(parentId)
+    const childGroupObj = await Group.find(childId)
+    publishAsync(publishGroupRelationshipUpdate, context, {
+      parentGroup: parentGroupObj,
+      childGroup: childGroupObj,
+      action: 'relationship_removed',
+      relationship: null
+    })
+
     return { success: true }
   }
   throw new GraphQLError("You don't have permission to do this")
 }
 
 // Called when a user joins an open group
-export async function joinGroup (groupId, userId, questionAnswers) {
+export async function joinGroup (groupId, userId, questionAnswers, context) {
   const user = await User.find(userId)
   if (!user) throw new GraphQLError(`User id ${userId} not found`)
   const group = await Group.find(groupId)
@@ -85,7 +111,12 @@ export async function joinGroup (groupId, userId, questionAnswers) {
       throw new GraphQLError(`You must be a member of group ${prereq.get('name')} first`)
     }
   })
-  return user.joinGroup(group, { questionAnswers })
+
+  const result = await user.joinGroup(group, { questionAnswers })
+
+  // Subscription publishing for group joins is handled in the background job Group.afterAddMembers
+
+  return result
 }
 
 export async function regenerateAccessCode (userId, groupId) {
@@ -97,28 +128,59 @@ export async function regenerateAccessCode (userId, groupId) {
 /**
  * As a host, removes member from a group.
  */
-export async function removeMember (loggedInUserId, userIdToRemove, groupId) {
+export async function removeMember (loggedInUserId, userIdToRemove, groupId, context) {
   const group = await getStewardedGroup(loggedInUserId, groupId, Responsibility.constants.RESP_REMOVE_MEMBERS)
+  const memberToRemove = await User.find(userIdToRemove)
+
   await GroupService.removeMember(userIdToRemove, groupId)
+
+  publishAsync(publishGroupMembershipUpdate, context, group, {
+    group,
+    member: memberToRemove,
+    action: 'left'
+  }, {
+    additionalUserIds: [userIdToRemove]
+  })
+
   return group
 }
 
-export async function removeModerator (userId, personId, groupId, isRemoveFromGroup) {
+export async function removeModerator (userId, personId, groupId, isRemoveFromGroup, context) {
   const group = await getStewardedGroup(userId, groupId, Responsibility.constants.RESP_ADMINISTRATION)
+  const person = await User.find(personId)
+
   if (isRemoveFromGroup) {
     await GroupMembership.removeModeratorRole(personId, group)
     await GroupService.removeMember(personId, groupId)
+
+    publishAsync(publishGroupMembershipUpdate, context, group, {
+      group,
+      member: person,
+      action: 'left'
+    }, {
+      additionalUserIds: [personId]
+    })
   } else {
     await GroupMembership.removeModeratorRole(personId, group)
+
+    publishAsync(publishGroupMembershipUpdate, context, group, {
+      group,
+      member: person,
+      action: 'moderator_removed'
+    })
   }
 
   return group
 }
 
-export async function updateGroup (userId, groupId, changes) {
+export async function updateGroup (userId, groupId, changes, context) {
   const group = await getStewardedGroup(userId, groupId, Responsibility.constants.RESP_ADMINISTRATION)
 
-  return group.update(convertGraphqlData(changes), userId)
+  const updatedGroup = await group.update(convertGraphqlData(changes), userId)
+
+  publishAsync(publishGroupUpdate, context, group, updatedGroup)
+
+  return updatedGroup
 }
 
 // Group to group relationship mutations
@@ -168,14 +230,26 @@ export async function inviteGroupToGroup (userId, fromId, toId, type, questionAn
   }
 }
 
-export async function acceptGroupRelationshipInvite (userId, groupRelationshipInviteId) {
+export async function acceptGroupRelationshipInvite (userId, groupRelationshipInviteId, context) {
   const invite = await GroupRelationshipInvite.where({ id: groupRelationshipInviteId }).fetch()
   if (invite) {
     if (GroupMembership.hasResponsibility(userId, invite.get('to_group_id'), Responsibility.constants.RESP_ADMINISTRATION)) {
       const groupRelationship = await invite.accept(userId)
-      await Queue.classMethod('Group', 'doesMenuUpdate', { groupRelationship: true, groupIds: group_ids })
+      const groupIds = [invite.get('from_group_id'), invite.get('to_group_id')]
+      await Queue.classMethod('Group', 'doesMenuUpdate', { groupRelationship: true, groupIds })
+
+      if (groupRelationship) {
+        const fromGroup = await Group.find(invite.get('from_group_id'))
+        const toGroup = await Group.find(invite.get('to_group_id'))
+        publishAsync(publishGroupRelationshipUpdate, context, {
+          parentGroup: invite.get('type') === GroupRelationshipInvite.TYPE.ParentToChild ? fromGroup : toGroup,
+          childGroup: invite.get('type') === GroupRelationshipInvite.TYPE.ParentToChild ? toGroup : fromGroup,
+          action: 'invite_accepted',
+          relationship: groupRelationship
+        })
+      }
+
       return { success: !!groupRelationship, groupRelationship }
-      
     } else {
       throw new GraphQLError('You do not have permission to do this')
     }

--- a/apps/backend/api/graphql/schema.graphql
+++ b/apps/backend/api/graphql/schema.graphql
@@ -319,6 +319,24 @@ type Query {
 
 union Update = Message | MessageThread | Notification
 
+# Group membership update payload for subscriptions
+type GroupMembershipUpdate {
+  group: Group
+  member: Person
+  # Action type: 'joined', 'left', 'role_changed', 'moderator_added', 'moderator_removed'
+  action: String
+  role: String
+}
+
+# Group relationship update payload for subscriptions
+type GroupRelationshipUpdate {
+  parentGroup: Group
+  childGroup: Group
+  # Action type: 'relationship_created', 'relationship_removed', 'invite_sent', 'invite_accepted', 'invite_rejected', 'invite_cancelled'
+  action: String
+  relationship: GroupRelationship
+}
+
 type Subscription {
   # Pushes new comments on the comments key for the given postId or parentCommentId
   comments(postId: ID, parentCommentId: ID): Comment,
@@ -329,6 +347,10 @@ type Subscription {
   # requested in the subscription query it is also where new messages and messageThreads can be received in the UI. See
   # example usage of this in Mobile.
   updates: Update
+  # Group-specific subscriptions for membership and relationship updates
+  groupUpdates: Group
+  groupMembershipUpdates: GroupMembershipUpdate  
+  groupRelationshipUpdates: GroupRelationshipUpdate
 }
 
 # The meta data associated with an Activity

--- a/apps/backend/api/models/Group.js
+++ b/apps/backend/api/models/Group.js
@@ -815,9 +815,34 @@ module.exports = bookshelf.Model.extend(merge({
     const zapierTriggers = await ZapierTrigger.forTypeAndGroups('new_member', groupId).fetchAll()
 
     const members = await User.query(q => q.whereIn('id', newUserIds.concat(reactivatedUserIds))).fetchAll()
+    const group = await Group.find(groupId)
+
+    // Publish group membership updates for new and reactivated members
+    if (group && members.length > 0) {
+      const { publishGroupMembershipUpdate } = require('../../lib/groupSubscriptionPublisher')
+
+      for (const member of members.models) {
+        const action = reactivatedUserIds.includes(member.id) ? 'rejoined' : 'joined'
+
+        if (process.env.NODE_ENV === 'development') {
+          console.log(`📡 Background job: Publishing membership update for ${member.get('name')} (${action})`)
+        }
+
+        try {
+          await publishGroupMembershipUpdate(null, group, {
+            group,
+            member,
+            action
+          }, {
+            additionalUserIds: [member.id] // Notify the new member
+          })
+        } catch (error) {
+          console.error('❌ Error publishing membership update in afterAddMembers:', error)
+        }
+      }
+    }
 
     if (zapierTriggers && zapierTriggers.length > 0) {
-      const group = await Group.find(groupId)
       for (const trigger of zapierTriggers) {
         await fetch(trigger.get('target_url'), {
           method: 'post',

--- a/apps/backend/lib/groupSubscriptionPublisher.js
+++ b/apps/backend/lib/groupSubscriptionPublisher.js
@@ -1,0 +1,165 @@
+/**
+ * Utilities for publishing group subscription updates in a non-blocking way
+ */
+
+import RedisPubSub from '../api/services/RedisPubSub'
+
+/**
+ * Publishes group updates to all members of a group
+ * @param {Object} context - GraphQL context with pubSub (optional)
+ * @param {Object} group - Group object with members
+ * @param {Object} groupData - Group data to publish
+ */
+export async function publishGroupUpdate (context, group, groupData) {
+  const pubSub = context?.pubSub || RedisPubSub
+  if (!pubSub) return
+
+  // Get all group members
+  const members = await group.members().fetch()
+  if (process.env.NODE_ENV === 'development') {
+    console.log(`📡 Publishing group update: ${groupData.name || groupData.get?.('name') || group.get('name')} (${groupData.id || groupData.get?.('id') || group.id}) to ${members.length} members`)
+  }
+
+  // Publish to each member's user channel
+  for (const member of members.models) {
+    if (process.env.NODE_ENV === 'development') {
+      console.log(`   → Notifying member ${member.get('name')} (${member.id})`)
+    }
+    pubSub.publish(`groupUpdates:${member.id}`, { group: groupData })
+  }
+
+  if (process.env.NODE_ENV === 'development') {
+    console.log(`✅ Successfully published ${members.length} group update notifications`)
+  }
+}
+
+/**
+ * Publishes membership updates to all group members
+ * @param {Object} context - GraphQL context with pubSub (optional)
+ * @param {Object} group - Group object with members
+ * @param {Object} membershipData - Membership update data
+ * @param {Object} options - Additional options
+ */
+export async function publishGroupMembershipUpdate (context, group, membershipData, options = {}) {
+  const pubSub = context?.pubSub || RedisPubSub
+  if (!pubSub) return
+
+  const { preloadedMembers, additionalUserIds = [] } = options
+
+  // Use preloaded members if provided, otherwise fetch them
+  const members = preloadedMembers || (await group.members().fetch())
+  const memberCount = Array.isArray(members) ? members.length : members.models?.length || 0
+
+  if (process.env.NODE_ENV === 'development') {
+    console.log(`📡 Publishing membership update: ${membershipData.member?.name || membershipData.member?.get?.('name')} ${membershipData.action} group ${membershipData.group?.name || membershipData.group?.get?.('name')} to ${memberCount} existing members`)
+  }
+
+  const membershipUpdate = {
+    group: membershipData.group,
+    member: membershipData.member,
+    action: membershipData.action,
+    role: membershipData.role || null
+  }
+
+  // Publish to each member's user channel
+  const membersList = Array.isArray(members) ? members : members.models
+  for (const member of membersList) {
+    const memberId = member.id || member.get('id')
+    const memberName = member.name || member.get('name')
+    if (process.env.NODE_ENV === 'development') {
+      console.log(`   → Notifying member ${memberName} (${memberId})`)
+    }
+    pubSub.publish(`groupMembershipUpdates:${memberId}`, { groupMembershipUpdate: membershipUpdate })
+  }
+
+  // Also notify additional users (like the person who was added/removed)
+  if (additionalUserIds.length > 0) {
+    if (process.env.NODE_ENV === 'development') {
+      console.log(`   → Also notifying ${additionalUserIds.length} additional users`)
+    }
+    for (const userId of additionalUserIds) {
+      pubSub.publish(`groupMembershipUpdates:${userId}`, { groupMembershipUpdate: membershipUpdate })
+    }
+  }
+
+  if (process.env.NODE_ENV === 'development') {
+    console.log(`✅ Successfully published ${memberCount + additionalUserIds.length} membership notifications`)
+  }
+}
+
+/**
+ * Publishes relationship updates to all members of both groups
+ * @param {Object} context - GraphQL context with pubSub (optional)
+ * @param {Object} relationshipData - Relationship update data
+ */
+export async function publishGroupRelationshipUpdate (context, relationshipData) {
+  const pubSub = context?.pubSub || RedisPubSub
+  if (!pubSub) return
+
+  const { parentGroup, childGroup, action, relationship } = relationshipData
+
+  // Get all members from both groups
+  const parentMembers = await parentGroup.members().fetch()
+  const childMembers = await childGroup.members().fetch()
+
+  // Combine and deduplicate members
+  const allMemberIds = new Set()
+  const allMembers = []
+  for (const member of parentMembers.models) {
+    if (!allMemberIds.has(member.id)) {
+      allMemberIds.add(member.id)
+      allMembers.push(member)
+    }
+  }
+  for (const member of childMembers.models) {
+    if (!allMemberIds.has(member.id)) {
+      allMemberIds.add(member.id)
+      allMembers.push(member)
+    }
+  }
+
+  if (process.env.NODE_ENV === 'development') {
+    console.log(`📡 Publishing relationship update: ${action} between ${parentGroup.get('name')} and ${childGroup.get('name')} to ${allMembers.length} combined members`)
+  }
+
+  const relationshipUpdate = {
+    parentGroup,
+    childGroup,
+    action,
+    relationship
+  }
+
+  // Publish to each member's user channel
+  for (const member of allMembers) {
+    if (process.env.NODE_ENV === 'development') {
+      console.log(`   → Notifying member ${member.get('name')} (${member.id})`)
+    }
+    pubSub.publish(`groupRelationshipUpdates:${member.id}`, { groupRelationshipUpdate: relationshipUpdate })
+  }
+
+  if (process.env.NODE_ENV === 'development') {
+    console.log(`✅ Successfully published ${allMembers.length} relationship notifications`)
+  }
+}
+
+/**
+ * Non-blocking wrapper that schedules publishing for next tick
+ * @param {Function} publishFunction - The publishing function to call
+ * @param {...any} args - Arguments to pass to the publishing function
+ */
+export function publishAsync (publishFunction, ...args) {
+  setImmediate(async () => {
+    try {
+      await publishFunction(...args)
+    } catch (error) {
+      console.error('❌ Error in background publishing:', error)
+    }
+  })
+}
+
+module.exports = {
+  publishGroupUpdate,
+  publishGroupMembershipUpdate,
+  publishGroupRelationshipUpdate,
+  publishAsync
+}

--- a/apps/mobile/src/navigation/AuthRootNavigator.js
+++ b/apps/mobile/src/navigation/AuthRootNavigator.js
@@ -37,6 +37,7 @@ import { twBackground } from 'style/colors'
 const updatesSubscription = gql`
   subscription UpdatesSubscription($firstMessages: Int = 1) {
     updates {
+      __typename
       ... on Notification {
         ...NotificationFieldsFragment
       }
@@ -57,11 +58,68 @@ const updatesSubscription = gql`
           unreadCount
         }
       }
-
     }
   }
   ${notificationFieldsFragment}
   ${messageThreadFieldsFragment}
+`
+
+const groupUpdatesSubscription = gql`
+  subscription GroupUpdatesSubscription {
+    groupUpdates {
+      id
+      name
+      slug
+      avatarUrl
+      memberCount
+      description
+    }
+  }
+`
+
+const groupMembershipUpdatesSubscription = gql`
+  subscription GroupMembershipUpdatesSubscription {
+    groupMembershipUpdates {
+      action
+      role
+      group {
+        id
+        name
+        slug
+        avatarUrl
+        memberCount
+      }
+      member {
+        id
+        name
+        avatarUrl
+      }
+    }
+  }
+`
+
+const groupRelationshipUpdatesSubscription = gql`
+  subscription GroupRelationshipUpdatesSubscription {
+    groupRelationshipUpdates {
+      action
+      parentGroup {
+        id
+        name
+        slug
+        avatarUrl
+      }
+      childGroup {
+        id
+        name
+        slug
+        avatarUrl
+      }
+      relationship {
+        id
+        createdAt
+      }
+    }
+  }
 `
 
 const AuthRoot = createStackNavigator()
@@ -78,6 +136,9 @@ export default function AuthRootNavigator () {
   const [, resetNotificationsCount] = useMutation(resetNotificationsCountMutation)
 
   useSubscription({ query: updatesSubscription })
+  useSubscription({ query: groupUpdatesSubscription })
+  useSubscription({ query: groupMembershipUpdatesSubscription })
+  useSubscription({ query: groupRelationshipUpdatesSubscription })
   useQuery({ query: notificationsQuery })
   useQuery({ query: commonRolesQuery })
   usePlatformAgreements()

--- a/packages/urql/updates/index.js
+++ b/packages/urql/updates/index.js
@@ -5,6 +5,9 @@ import makeAppendToPaginatedSetResolver from './makeAppendToPaginatedSetResolver
 import { reactOn, deleteReaction } from './reactions'
 import { handleReactionPostCompletion } from './sideEffectPostCompletion'
 
+// Set to true to enable debug logging for group subscriptions
+const isDev = false
+
 export default {
   Mutation: {
     addProposalVote: (result, args, cache, info) => {
@@ -110,7 +113,7 @@ export default {
       }
     },
 
-    removeProposalVote: (result, args, cache, info) => { 
+    removeProposalVote: (result, args, cache, info) => {
       cache.invalidate({ __typename: 'Post', id: args.postId })
     },
 
@@ -142,8 +145,9 @@ export default {
 
       if (!updatedMembership?.id) return
 
-      cache.updateQuery({ query: meQuery }, ({ me }) => {
-        if (!me) return null
+      cache.updateQuery({ query: meQuery }, (data) => {
+        if (!data?.me) return null
+        const { me } = data
 
         return {
           me: {
@@ -157,6 +161,150 @@ export default {
     },
 
     verifyEmail: (result, args, cache, info) => {
+      cache.invalidate('Query', 'me')
+    },
+
+    acceptGroupRelationshipInvite: (result, args, cache, info) => {
+      if (result.acceptGroupRelationshipInvite.success) {
+        // Refresh group queries for both parent and child groups
+        const groupFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'group')
+        groupFields.forEach(field => {
+          cache.invalidate('Query', field.fieldKey)
+        })
+
+        // Refresh groups list queries to show updated relationships
+        const groupsFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'groups')
+        groupsFields.forEach(field => {
+          cache.invalidate('Query', field.fieldKey)
+        })
+      }
+    },
+
+    addModerator: (result, args, cache, info) => {
+      const { groupId } = args
+      cache.invalidate({ __typename: 'Group', id: groupId })
+    },
+
+    addPostToCollection: (result, args, cache, info) => {
+      const { collectionId } = args
+      cache.invalidate({ __typename: 'Collection', id: collectionId })
+    },
+
+    addRoleToMember: (result, args, cache, info) => {
+      const { groupId } = args
+      cache.invalidate({ __typename: 'Group', id: groupId })
+    },
+
+    cancelGroupRelationshipInvite: (result, args, cache, info) => {
+      if (result.cancelGroupRelationshipInvite.success) {
+        // Refresh group queries
+        const groupFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'group')
+        groupFields.forEach(field => {
+          cache.invalidate('Query', field.fieldKey)
+        })
+
+        // Refresh groups list queries
+        const groupsFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'groups')
+        groupsFields.forEach(field => {
+          cache.invalidate('Query', field.fieldKey)
+        })
+      }
+    },
+
+    createInvitation: (result, args, cache, info) => {
+      const { groupId } = args
+      cache.invalidate({ __typename: 'Group', id: groupId })
+    },
+
+    createPost: (result, args, cache, info) => {
+      cache.invalidate('Query', 'posts')
+    },
+
+    deleteGroupRelationship: (result, args, cache, info) => {
+      if (result.deleteGroupRelationship.success) {
+        // Refresh group queries for both parent and child groups
+        const groupFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'group')
+        groupFields.forEach(field => {
+          cache.invalidate('Query', field.fieldKey)
+        })
+
+        // Refresh groups list queries to show updated relationships
+        const groupsFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'groups')
+        groupsFields.forEach(field => {
+          cache.invalidate('Query', field.fieldKey)
+        })
+      }
+    },
+
+    joinGroup: (result, args, cache, info) => {
+      const { groupId } = args
+      cache.invalidate({ __typename: 'Group', id: groupId })
+      cache.invalidate('Query', 'me')
+    },
+
+    leaveGroup: (result, args, cache, info) => {
+      const { id } = args
+      cache.invalidate({ __typename: 'Group', id })
+      cache.invalidate('Query', 'me')
+    },
+
+    rejectGroupRelationshipInvite: (result, args, cache, info) => {
+      if (result.rejectGroupRelationshipInvite.success) {
+        // Refresh group queries
+        const groupFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'group')
+        groupFields.forEach(field => {
+          cache.invalidate('Query', field.fieldKey)
+        })
+
+        // Refresh groups list queries
+        const groupsFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'groups')
+        groupsFields.forEach(field => {
+          cache.invalidate('Query', field.fieldKey)
+        })
+      }
+    },
+
+    removeMember: (result, args, cache, info) => {
+      const { groupId } = args
+      cache.invalidate({ __typename: 'Group', id: groupId })
+    },
+
+    removeModerator: (result, args, cache, info) => {
+      const { groupId } = args
+      cache.invalidate({ __typename: 'Group', id: groupId })
+    },
+
+    removeRoleFromMember: (result, args, cache, info) => {
+      const { groupId } = args
+      cache.invalidate({ __typename: 'Group', id: groupId })
+    },
+
+    requestToAddGroupToParent: (result, args, cache, info) => {
+      if (result.requestToAddGroupToParent.success) {
+        // Refresh group queries
+        const groupFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'group')
+        groupFields.forEach(field => {
+          cache.invalidate('Query', field.fieldKey)
+        })
+
+        // Refresh groups list queries
+        const groupsFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'groups')
+        groupsFields.forEach(field => {
+          cache.invalidate('Query', field.fieldKey)
+        })
+      }
+    },
+
+    updateGroupSettings: (result, args, cache, info) => {
+      const { id } = args
+      cache.invalidate({ __typename: 'Group', id })
+    },
+
+    updatePost: (result, args, cache, info) => {
+      cache.invalidate('Query', 'posts')
+    },
+
+    useInvitation: (result, args, cache, info) => {
       cache.invalidate('Query', 'me')
     }
   },
@@ -180,8 +328,9 @@ export default {
             fieldName: 'messages'
           })(result, args, cache, info)
           cache.invalidate({ __typename: 'MessageThread', id: update?.messageThread?.id })
-          cache.updateQuery({ query: meQuery }, ({ me }) => {
-            if (!me) return null
+          cache.updateQuery({ query: meQuery }, (data) => {
+            if (!data?.me) return null
+            const { me } = data
             return { me: { ...me, unseenThreadCount: me.unseenThreadCount + 1 } }
           })
           return
@@ -192,8 +341,9 @@ export default {
             parentType: 'Me',
             fieldName: 'messageThreads'
           })(result, args, cache, info)
-          cache.updateQuery({ query: meQuery }, ({ me }) => {
-            if (!me) return null
+          cache.updateQuery({ query: meQuery }, (data) => {
+            if (!data?.me) return null
+            const { me } = data
             return { me: { ...me, unseenThreadCount: me.unseenThreadCount + 1 } }
           })
           return
@@ -204,8 +354,9 @@ export default {
             parentType: 'Query',
             fieldName: 'notifications'
           })(result, args, cache, info)
-          cache.updateQuery({ query: meQuery }, ({ me }) => {
-            if (!me) return null
+          cache.updateQuery({ query: meQuery }, (data) => {
+            if (!data?.me) return null
+            const { me } = data
             return { me: { ...me, newNotificationCount: me.newNotificationCount + 1 } }
           })
           return
@@ -214,6 +365,140 @@ export default {
         default: {
           console.log('ℹ️ Unhandled update from updates subscription', result, args)
         }
+      }
+    },
+
+    groupUpdates: (result, args, cache, info) => {
+      const update = result?.groupUpdates
+
+      if (update) {
+        if (isDev) {
+          console.log(`📱 Received group update: ${update.name} (${update.id})`)
+        }
+
+        // Invalidate the specific group to trigger a refetch with updated data
+        cache.invalidate({ __typename: 'Group', id: update.id })
+
+        // Also invalidate any group queries that might include this group
+        const groupFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'group')
+        groupFields.forEach(field => {
+          // Check if this field is for the updated group
+          if (field.arguments?.id === update.id || field.arguments?.slug === update.slug) {
+            cache.invalidate('Query', field.fieldKey)
+          }
+        })
+
+        // Invalidate groups list queries
+        const groupsFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'groups')
+        groupsFields.forEach(field => {
+          cache.invalidate('Query', field.fieldKey)
+        })
+
+        // Update Me query to reflect any group changes
+        cache.updateQuery({ query: meQuery }, (data) => {
+          if (!data?.me) return null
+          // Force refetch of user's groups by invalidating
+          return data
+        })
+      }
+    },
+
+    groupMembershipUpdates: (result, args, cache, info) => {
+      const update = result?.groupMembershipUpdates
+
+      if (update) {
+        if (isDev) {
+          console.log(`📱 Received membership update: ${update.member.name} ${update.action} ${update.group.name}`)
+        }
+
+        // Invalidate the specific group to trigger membership refetch
+        cache.invalidate({ __typename: 'Group', id: update.group.id })
+
+        // Update Me query to reflect membership changes
+        cache.updateQuery({ query: meQuery }, (data) => {
+          if (!data?.me) return null
+
+          const { me } = data
+          const existingMemberships = me.memberships || []
+          if (update.action === 'joined' || update.action === 'rejoined') {
+            // Check if membership already exists
+            const existingMembership = existingMemberships.find(m => m.group.id === update.group.id)
+            if (!existingMembership) {
+              // Add new membership
+              const newMembership = {
+                __typename: 'GroupMembership',
+                id: `temp-${update.group.id}`, // Temporary ID
+                group: update.group,
+                role: update.role || 0,
+                hasModeratorRole: update.role === 1,
+                settings: {}
+              }
+              return {
+                me: {
+                  ...me,
+                  memberships: [...existingMemberships, newMembership]
+                }
+              }
+            }
+          } else if (update.action === 'left') {
+            // Remove membership
+            const filteredMemberships = existingMemberships.filter(m => m.group.id !== update.group.id)
+            return {
+              me: {
+                ...me,
+                memberships: filteredMemberships
+              }
+            }
+          }
+
+          return data
+        })
+
+        // Invalidate related group queries
+        const groupFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'group')
+        groupFields.forEach(field => {
+          if (field.arguments?.id === update.group.id || field.arguments?.slug === update.group.slug) {
+            cache.invalidate('Query', field.fieldKey)
+          }
+        })
+
+        // Invalidate groups list queries
+        const groupsFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'groups')
+        groupsFields.forEach(field => {
+          cache.invalidate('Query', field.fieldKey)
+        })
+      }
+    },
+
+    groupRelationshipUpdates: (result, args, cache, info) => {
+      const update = result?.groupRelationshipUpdates
+
+      if (update) {
+        if (isDev) {
+          console.log(`📱 Received relationship update: ${update.action} between ${update.parentGroup.name} and ${update.childGroup.name}`)
+        }
+
+        // Invalidate both groups involved in the relationship
+        cache.invalidate({ __typename: 'Group', id: update.parentGroup.id })
+        cache.invalidate({ __typename: 'Group', id: update.childGroup.id })
+
+        // Invalidate group queries for both groups
+        const groupFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'group')
+        groupFields.forEach(field => {
+          const groupId = field.arguments?.id
+          const groupSlug = field.arguments?.slug
+
+          if (groupId === update.parentGroup.id || groupId === update.childGroup.id ||
+              groupSlug === update.parentGroup.slug || groupSlug === update.childGroup.slug) {
+            cache.invalidate('Query', field.fieldKey)
+          }
+        })
+
+        // Invalidate groups list queries to reflect relationship changes
+        const groupsFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'groups')
+        groupsFields.forEach(field => {
+          cache.invalidate('Query', field.fieldKey)
+        })
       }
     }
   }


### PR DESCRIPTION
This PR adds more subscriptions to mobile and the backend, increasing the range of Group related mutations that will automatically push updates to subscribed clients, keeping client state in better sync with the server/db.

Closes #657 