### PR TITLE
dropdown for post editor higher in stack

### DIFF
--- a/apps/web/src/components/DropdownButton/DropdownButton.js
+++ b/apps/web/src/components/DropdownButton/DropdownButton.js
@@ -55,7 +55,7 @@ export default class DropdownButton extends Component {
     const { expanded } = this.state
 
     return (
-      <div className='relative'>
+      <div className='relative z-20'>
         {/* Main button that toggles the dropdown */}
         <div
           role='button'


### PR DESCRIPTION
The bottom of the dropdown button for post editor modal was obscured by "add a comment" entry element. This may affect other uses of dropdown, please consider and do whatever is appropriate. Thanks :-)