### PR TITLE
fix Maximum update depth exceeded

### DIFF
--- a/apps/web/src/routes/AuthLayoutRouter/components/GlobalNav/GlobalNav.jsx
+++ b/apps/web/src/routes/AuthLayoutRouter/components/GlobalNav/GlobalNav.jsx
@@ -70,9 +70,10 @@ export default function GlobalNav (props) {
     return () => {
       if (menuTimeoutId) {
         clearTimeout(menuTimeoutId)
+        setMenuTimeoutId(null)
       }
     }
-  }, [isContainerHovered, menuTimeoutId])
+  }, [isContainerHovered])
 
   // Add effect to handle scroll position updates for tooltips
   useEffect(() => {


### PR DESCRIPTION
I noticed that on mouse enter, I'd get a "Maximum update depth exceeded" caused by the timeout constantly cycling in the `useEffect` on line 52.

@brodeur I notice that you modified something around this for GlobalNav scrolling, this PR may break that feature, but I'm not sure how to test it.