### PR TITLE
Subscriptions fix

### DIFF
--- a/apps/backend/api/graphql/makeSchema.js
+++ b/apps/backend/api/graphql/makeSchema.js
@@ -191,6 +191,17 @@ export default async function makeSchema ({ req }) {
           if (foundType) return foundType
           throw new Error(`Unable to determine GraphQL type for instance: ${data}`)
         }
+      },
+      // Type resolver for the SubscriptionUpdate union type used in allUpdates subscription
+      SubscriptionUpdate: {
+        __resolveType (data, context, info) {
+          // Use makeModelsType if set by the subscription resolver
+          if (data?.makeModelsType) return data.makeModelsType
+
+          const foundType = getTypeForInstance(data, models)
+          if (foundType) return foundType
+          throw new Error(`Unable to determine GraphQL type for SubscriptionUpdate: ${data}`)
+        }
       }
     }
   } else if (req.api_client) {

--- a/apps/backend/api/graphql/makeSubscriptions.js
+++ b/apps/backend/api/graphql/makeSubscriptions.js
@@ -136,6 +136,98 @@ export default function makeSubscriptions () {
           return new Post(payload.post)
         }
       }
+    },
+
+    // UNIFIED SUBSCRIPTION: Combines all user-specific updates into a single stream
+    // This reduces the number of SSE connections needed (helpful for Android's 4-connection limit)
+    allUpdates: {
+      subscribe: async function * (parent, args, context) {
+        const userId = context.currentUserId
+
+        if (process.env.NODE_ENV === 'development') {
+          console.log(`🔧 Setting up unified subscription for user ${userId}`)
+        }
+
+        // Create individual subscription iterators
+        const subscriptions = [
+          pipe(context.pubSub.subscribe(`updates:${userId}`), withDontSendToCreator({ context })),
+          pipe(context.pubSub.subscribe(`groupUpdates:${userId}`), withDontSendToCreator({ context })),
+          pipe(context.pubSub.subscribe(`groupMembershipUpdates:${userId}`), withDontSendToCreator({ context })),
+          pipe(context.pubSub.subscribe(`groupRelationshipUpdates:${userId}`), withDontSendToCreator({ context })),
+          pipe(context.pubSub.subscribe(`postUpdates:${userId}`), withDontSendToCreator({ context }))
+        ]
+
+        // Merge all subscription streams
+        const mergedStream = async function * () {
+          const iterators = subscriptions.map(sub => sub[Symbol.asyncIterator]())
+          const promises = iterators.map((iterator, index) =>
+            iterator.next().then(result => ({ result, index }))
+          )
+
+          while (promises.length > 0) {
+            const { result, index } = await Promise.race(promises.filter(Boolean))
+
+            if (!result.done) {
+              if (process.env.NODE_ENV === 'development') {
+                const streamNames = ['updates', 'groupUpdates', 'groupMembershipUpdates', 'groupRelationshipUpdates', 'postUpdates']
+                console.log(`🔧 Unified subscription yielding from ${streamNames[index]} stream:`, Object.keys(result.value))
+              }
+
+              yield result.value
+
+              // Replace the resolved promise with the next value from the same iterator
+              promises[index] = iterators[index].next().then(nextResult => ({ result: nextResult, index }))
+            } else {
+              // Remove completed iterator
+              promises[index] = null
+            }
+          }
+        }
+
+        yield * mergedStream()
+      },
+      resolve: (payload) => {
+        // Route payload to appropriate type based on content
+        if (payload?.message) {
+          const message = new Comment(payload.message)
+          message.makeModelsType = 'Message'
+          return message
+        }
+        if (payload?.messageThread) {
+          const messageThread = new Post(payload.messageThread)
+          messageThread.makeModelsType = 'MessageThread'
+          return messageThread
+        }
+        if (payload?.notification) {
+          return new Notification(payload.notification)
+        }
+        if (payload?.group) {
+          return new Group(payload.group)
+        }
+        if (payload?.groupMembershipUpdate) {
+          return {
+            group: new Group(payload.groupMembershipUpdate.group),
+            member: new User(payload.groupMembershipUpdate.member),
+            action: payload.groupMembershipUpdate.action,
+            role: payload.groupMembershipUpdate.role,
+            makeModelsType: 'GroupMembershipUpdate'
+          }
+        }
+        if (payload?.groupRelationshipUpdate) {
+          return {
+            parentGroup: new Group(payload.groupRelationshipUpdate.parentGroup),
+            childGroup: new Group(payload.groupRelationshipUpdate.childGroup),
+            action: payload.groupRelationshipUpdate.action,
+            relationship: payload.groupRelationshipUpdate.relationship ? new GroupRelationship(payload.groupRelationshipUpdate.relationship) : null,
+            makeModelsType: 'GroupRelationshipUpdate'
+          }
+        }
+        if (payload?.post) {
+          return new Post(payload.post)
+        }
+
+        return null
+      }
     }
   }
 }

--- a/apps/backend/api/graphql/schema.graphql
+++ b/apps/backend/api/graphql/schema.graphql
@@ -337,6 +337,9 @@ type GroupRelationshipUpdate {
   relationship: GroupRelationship
 }
 
+# Union type for all possible subscription updates
+union SubscriptionUpdate = Notification | Group | GroupMembershipUpdate | GroupRelationshipUpdate | Post | Comment | Person
+
 type Subscription {
   # Pushes new comments on the comments key for the given postId or parentCommentId
   comments(postId: ID, parentCommentId: ID): Comment,
@@ -353,6 +356,10 @@ type Subscription {
   groupRelationshipUpdates: GroupRelationshipUpdate
   # Post updates subscription for real-time post changes
   postUpdates: Post
+  
+  # UNIFIED: Single subscription that combines all user-specific updates
+  # Reduces Android SSE connection limit issues by using only one connection
+  allUpdates: SubscriptionUpdate
 }
 
 # The meta data associated with an Activity
@@ -2053,10 +2060,10 @@ type Post {
   createdAt: Date
   # The body of the post
   details: String
+  # When the text was last edited
+  editedAt: Date
   # Link to a donation page, only used for projects only right now
   donationsLink: String
-  # When this post was last significantly edited (such as title and details)
-  editedAt: Date
   # When this post "ends". Used for events, resources, projects, requests and offers right now
   endTime: Date
   # List of group ids for groups that have flagged this post

--- a/apps/backend/lib/postSubscriptionPublisher.js
+++ b/apps/backend/lib/postSubscriptionPublisher.js
@@ -54,6 +54,9 @@ export async function publishPostUpdate (context, post, options = {}) {
 
     // Publish to each follower's user channel
     for (const userId of followerIds) {
+      if (process.env.NODE_ENV === 'development') {
+        console.log(`   → Publishing to user ${userId} on channel postUpdates:${userId}`)
+      }
       pubSub.publish(`postUpdates:${userId}`, { post: postUpdateData })
     }
 

--- a/apps/mobile/android/app/src/debug/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/debug/AndroidManifest.xml
@@ -3,7 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
-        android:usesCleartextTraffic="true"
-        tools:targetApi="28"
-        tools:ignore="GoogleAppIndexingWarning"/>
+        android:networkSecurityConfig="@xml/network_security_config"
+        tools:ignore="GoogleAppIndexingWarning"
+        tools:targetApi="28" />
+
 </manifest>

--- a/apps/mobile/android/app/src/debug/res/xml/network_security_config.xml
+++ b/apps/mobile/android/app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">localhost</domain>
+        <domain includeSubdomains="true">10.0.2.2</domain>
+        <domain includeSubdomains="true">10.0.3.2</domain>
+    </domain-config>
+</network-security-config>

--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
     android:roundIcon="@mipmap/ic_launcher_round"
     android:allowBackup="false"
     android:theme="@style/AppTheme"
+    tools:replace="android:allowBackup"
     android:supportsRtl="true">
     <meta-data
       android:name="com.facebook.sdk.ApplicationId"

--- a/apps/mobile/src/navigation/AuthRootNavigator.js
+++ b/apps/mobile/src/navigation/AuthRootNavigator.js
@@ -3,13 +3,11 @@ import { Platform } from 'react-native'
 import { createStackNavigator } from '@react-navigation/stack'
 import Intercom from '@intercom/intercom-react-native'
 import { LogLevel, OneSignal } from 'react-native-onesignal'
-import { gql, useMutation, useQuery, useSubscription } from 'urql'
+import { useMutation, useQuery } from 'urql'
 import mixpanel from 'services/mixpanel'
 import { useTranslation } from 'react-i18next'
 import resetNotificationsCountMutation from '@hylo/graphql/mutations/resetNotificationsCountMutation'
 import notificationsQuery from '@hylo/graphql/queries/notificationsQuery'
-import messageThreadFieldsFragment from '@hylo/graphql/fragments/messageThreadFieldsFragment'
-import notificationFieldsFragment from '@hylo/graphql/fragments/notificationFieldsFragment'
 import commonRolesQuery from '@hylo/graphql/queries/commonRolesQuery'
 import useCurrentUser from '@hylo/hooks/useCurrentUser'
 import usePlatformAgreements from '@hylo/hooks/usePlatformAgreements'
@@ -33,163 +31,9 @@ import NotificationsList from 'screens/NotificationsList'
 import Thread from 'screens/Thread'
 import UploadAction from 'screens/UploadAction'
 import { twBackground } from 'style/colors'
+import useUnifiedSubscription from '@hylo/hooks/useUnifiedSubscription'
 
-const updatesSubscription = gql`
-  subscription UpdatesSubscription($firstMessages: Int = 1) {
-    updates {
-      __typename
-      ... on Notification {
-        ...NotificationFieldsFragment
-      }
-      ... on MessageThread {
-        ...MessageThreadFieldsFragment
-      }
-      ... on Message {
-        id
-        createdAt
-        text
-        creator {
-          id
-          name
-          avatarUrl
-        }
-        messageThread {
-          id
-          unreadCount
-        }
-      }
-    }
-  }
-  ${notificationFieldsFragment}
-  ${messageThreadFieldsFragment}
-`
 
-const groupUpdatesSubscription = gql`
-  subscription GroupUpdatesSubscription {
-    groupUpdates {
-      id
-      name
-      slug
-      avatarUrl
-      memberCount
-      description
-    }
-  }
-`
-
-const groupMembershipUpdatesSubscription = gql`
-  subscription GroupMembershipUpdatesSubscription {
-    groupMembershipUpdates {
-      action
-      role
-      group {
-        id
-        name
-        slug
-        avatarUrl
-        memberCount
-      }
-      member {
-        id
-        name
-        avatarUrl
-      }
-    }
-  }
-`
-
-const groupRelationshipUpdatesSubscription = gql`
-  subscription GroupRelationshipUpdatesSubscription {
-    groupRelationshipUpdates {
-      action
-      parentGroup {
-        id
-        name
-        slug
-        avatarUrl
-      }
-      childGroup {
-        id
-        name
-        slug
-        avatarUrl
-      }
-      relationship {
-        id
-        createdAt
-      }
-    }
-  }
-`
-
-const postUpdatesSubscription = gql`
-  subscription PostUpdatesSubscription {
-    postUpdates {
-      id
-      updatedAt
-      # Comment-related fields
-      commentsTotal
-      comments {
-        total
-        items {
-          id
-          text
-          createdAt
-          creator {
-            id
-            name
-            avatarUrl
-          }
-        }
-      }
-      # Reaction-related fields
-      peopleReactedTotal
-      reactionsSummary
-      postReactions {
-        id
-        emojiFull
-        emojiBase
-        user {
-          id
-          name
-        }
-      }
-      # Post edit fields
-      title
-      details
-      type
-      location
-      startTime
-      endTime
-      # Proposal vote fields (for proposal posts only)
-      proposalStatus
-      proposalOutcome
-      proposalOptions {
-        total
-        items {
-          id
-          text
-          emoji
-          color
-        }
-      }
-      proposalVotes {
-        total
-        items {
-          id
-          optionId
-          user {
-            id
-            name
-          }
-        }
-      }
-      # Completion fields
-      fulfilledAt
-      completedAt
-    }
-  }
-`
 
 const AuthRoot = createStackNavigator()
 export default function AuthRootNavigator () {
@@ -204,11 +48,10 @@ export default function AuthRootNavigator () {
   const [initialized, setInitialize] = useState(false)
   const [, resetNotificationsCount] = useMutation(resetNotificationsCountMutation)
 
-  useSubscription({ query: updatesSubscription })
-  useSubscription({ query: groupUpdatesSubscription })
-  useSubscription({ query: groupMembershipUpdatesSubscription })
-  useSubscription({ query: groupRelationshipUpdatesSubscription })
-  useSubscription({ query: postUpdatesSubscription })
+  // ANDROID SSE LIMIT: Use unified subscription instead of individual ones
+  // This stays within Android's 4 concurrent SSE connection limit
+  useUnifiedSubscription()
+  
   useQuery({ query: notificationsQuery })
   useQuery({ query: commonRolesQuery })
   usePlatformAgreements()

--- a/apps/mobile/src/screens/NoContextFallbackScreen/NoContextFallbackScreen.js
+++ b/apps/mobile/src/screens/NoContextFallbackScreen/NoContextFallbackScreen.js
@@ -3,6 +3,7 @@ import { View } from 'react-native'
 import useCurrentGroup from '@hylo/hooks/useCurrentGroup'
 import ContextSwitchMenu from 'components/ContextSwitchMenu'
 import LoadingScreen from 'screens/LoadingScreen'
+import Loading from 'components/Loading'
 import { useChangeToGroup } from 'hooks/useHandleCurrentGroup'
 
 export default function NoContextFallbackScreen () {

--- a/apps/mobile/src/urql/mobileSubscriptionExchange.js
+++ b/apps/mobile/src/urql/mobileSubscriptionExchange.js
@@ -2,67 +2,133 @@ import { subscriptionExchange } from 'urql'
 import EventSource from 'react-native-sse'
 import { URL } from 'react-native-url-polyfill'
 import { GRAPHQL_ENDPOINT_URL } from '@hylo/urql/makeUrqlClient'
+import { getSessionCookie } from 'util/session'
 
 // Set to 0 for infinite retries, or a number to limit attempts
 const MAX_RETRIES = 0
 const BASE_RETRY_DELAY_MS = 1 * 1000
 const RETRY_CAP_MS = 30 * 1000
-
-let retryCount = 0
-let isReconnecting = false
-let globalEventSource = null
-
-const resetRetryState = () => {
-  retryCount = 0
-  isReconnecting = false
-}
+const subscriptionLoggingOn = process.env.NODE_ENV === 'development' && true // Flip this off if you don't want to see the logs
 
 const exponentialBackoff = (attempt) => Math.min(BASE_RETRY_DELAY_MS * (2 ** attempt), RETRY_CAP_MS)
 
-const connectSubscription = (url, sink) => {
-  console.log('Connecting graphql subscriptions...')
+const connectSubscription = async (url, sink) => {
+  if (subscriptionLoggingOn) {
+    console.log('Connecting graphql subscription for:', url.searchParams.get('query')?.substring(0, 50) + '...')
+  }
+  
+  let retryCount = 0
+  let isReconnecting = false
+  let eventSource = null
 
-  globalEventSource = new EventSource(url.toString(), {
-    withCredentials: true,
-    credentials: 'include',
-    method: 'GET',
-    lineEndingCharacter: '\n'
-  })
+  const resetRetryState = () => {
+    retryCount = 0
+    isReconnecting = false
+  }
 
-  globalEventSource.addEventListener('next', (event) => {
-    try {
-      const data = JSON.parse(event.data)
-      sink.next(data)
-      resetRetryState() // Reset retries on successful connection
-    } catch (error) {
-      console.error('Error parsing SSE message:', error)
-    }
-  })
-
-  globalEventSource.addEventListener('error', (event) => {
-    if (isReconnecting) return
-
-    console.error('Subscription error:', event?.message || 'Unknown error')
-
-    retryCount++
-    isReconnecting = true
-
-    globalEventSource.close()
-
-    // Stop retrying if MAX_RETRIES is set and exceeded (unless it's 0 for infinite retries)
-    if (MAX_RETRIES > 0 && retryCount >= MAX_RETRIES) {
-      console.error('Max retries reached. No further attempts.')
-      return
+  const createConnection = async () => {
+    // Get session cookie for authentication
+    const sessionCookie = await getSessionCookie()
+    
+    const headers = {}
+    if (sessionCookie) {
+      headers.Cookie = sessionCookie
     }
 
-    const retryDelay = exponentialBackoff(retryCount)
-    console.log(`Retrying subscription in ${retryDelay / 1000} seconds...`)
+    eventSource = new EventSource(url.toString(), {
+      withCredentials: true,
+      credentials: 'include',
+      method: 'GET',
+      lineEndingCharacter: '\n',
+      headers
+    })
 
-    setTimeout(() => {
-      isReconnecting = false
-      connectSubscription(url, sink)
-    }, retryDelay)
-  })
+    eventSource.addEventListener('open', () => {
+      if (subscriptionLoggingOn) {
+        console.log('Subscription connection opened for:', url.searchParams.get('query')?.substring(0, 50) + '...')
+      }
+      resetRetryState()
+    })
+
+    eventSource.addEventListener('next', (event) => {
+      try {
+        const data = JSON.parse(event.data)
+        
+        if (subscriptionLoggingOn) {
+          console.log('📱 SSE received data:', {
+            type: data.type || data.event || 'unknown',
+            keys: Object.keys(data),
+            errors: data.errors,
+            hasData: !!data.data,
+            dataKeys: data.data ? Object.keys(data.data) : null
+          })
+          
+          if (data?.data?.allUpdates?.__typename === 'Post') {
+            console.log('📱 SSE received Post update:', data.data.allUpdates.id)
+          }
+        }
+        
+        sink.next(data)
+      } catch (error) {
+        console.error('Error parsing SSE message:', error)
+      }
+    })
+
+    eventSource.addEventListener('close', (event) => {
+      if (subscriptionLoggingOn) {
+        console.log('Subscription connection closed.', JSON.stringify(event, null, 2))
+      }
+      // This event doesn't automatically mean an error, but in our case,
+      // a close is unexpected, so we'll trigger the reconnection logic.
+      handleConnectionError({ message: 'Connection closed unexpectedly' })
+    })
+
+    const handleConnectionError = (event) => {
+      if (isReconnecting) return
+
+      console.error('Subscription error. Full event:', JSON.stringify(event, null, 2))
+      console.error('Subscription error message:', event?.message || 'Unknown error')
+
+      retryCount++
+      isReconnecting = true
+
+      if (eventSource) {
+        eventSource.close()
+      }
+
+      // Stop retrying if MAX_RETRIES is set and exceeded (unless it's 0 for infinite retries)
+      if (MAX_RETRIES > 0 && retryCount >= MAX_RETRIES) {
+        console.error('Max retries reached. No further attempts.')
+        return
+      }
+
+      const retryDelay = exponentialBackoff(retryCount)
+      if (subscriptionLoggingOn) {
+        console.log(`Retrying subscription in ${retryDelay / 1000} seconds...`)
+      }
+
+      setTimeout(() => {
+        isReconnecting = false
+        createConnection()
+      }, retryDelay)
+    }
+
+    eventSource.addEventListener('error', handleConnectionError)
+  }
+
+  await createConnection()
+
+  return {
+    unsubscribe: () => {
+      if (eventSource) {
+        if (subscriptionLoggingOn) {
+          console.log('Unsubscribing from SSE stream')
+        }
+        eventSource.close()
+      }
+      resetRetryState()
+    }
+  }
 }
 
 export default subscriptionExchange({
@@ -76,15 +142,12 @@ export default subscriptionExchange({
 
     return {
       subscribe: (sink) => {
-        connectSubscription(url, sink)
+        const connectionPromise = connectSubscription(url, sink)
 
         return {
-          unsubscribe: () => {
-            if (globalEventSource) {
-              console.log('Unsubscribing from SSE stream')
-              globalEventSource.close()
-            }
-            resetRetryState()
+          unsubscribe: async () => {
+            const connection = await connectionPromise
+            connection.unsubscribe()
           }
         }
       }

--- a/packages/hooks/useUnifiedSubscription.js
+++ b/packages/hooks/useUnifiedSubscription.js
@@ -1,0 +1,143 @@
+import { gql, useSubscription } from 'urql'
+
+const UNIFIED_SUBSCRIPTION = gql`
+  subscription UnifiedSubscription {
+    allUpdates {
+      __typename
+      ... on Notification {
+        id
+        createdAt
+        activity {
+          id
+          action
+          actor {
+            id
+            name
+            avatarUrl
+          }
+          comment {
+            id
+            text
+          }
+          post {
+            id
+            title
+            details
+            groups {
+              id
+              slug
+            }
+          }
+          group {
+            id
+            name
+            slug
+          }
+          track {
+            id
+            name
+          }
+          meta {
+            reasons
+          }
+          unread
+        }
+      }
+      ... on Group {
+        id
+        name
+        slug
+        avatarUrl
+        memberCount
+        description
+      }
+      ... on GroupMembershipUpdate {
+        action
+        role
+        group {
+          id
+          name
+          slug
+          avatarUrl
+          memberCount
+        }
+        member {
+          id
+          name
+          avatarUrl
+        }
+      }
+      ... on GroupRelationshipUpdate {
+        action
+        parentGroup {
+          id
+          name
+          slug
+          avatarUrl
+        }
+        childGroup {
+          id
+          name
+          slug
+          avatarUrl
+        }
+        relationship {
+          id
+          createdAt
+        }
+      }
+      ... on Post {
+        id
+        updatedAt
+        title
+        details
+        type
+        commentsTotal
+        peopleReactedTotal
+        reactionsSummary
+        postReactions {
+          id
+          emojiFull
+          emojiBase
+          user {
+            id
+            name
+          }
+        }
+        fulfilledAt
+        completedAt
+      }
+      ... on Comment {
+        id
+        text
+        createdAt
+        creator {
+          id
+          name
+          avatarUrl
+        }
+        # This will be a Message if makeModelsType is set
+      }
+    }
+  }
+`
+
+/**
+ * Custom hook that subscribes to the unified subscription stream
+ * and handles all update types in a single connection.
+ *
+ * This replaces the need for multiple individual subscriptions,
+ * which helps with Android's 4 SSE connection limit.
+ */
+export default function useUnifiedSubscription () {
+  const [result] = useSubscription({
+    query: UNIFIED_SUBSCRIPTION,
+    pause: false // Always active
+  })
+
+  // The subscription handling is done automatically by urql's cache system
+  // The cache updates are handled by the existing update functions in packages/urql/updates
+  // since they key off the typename and payload structure
+
+  return result
+}

--- a/packages/urql/makeUrqlClient.js
+++ b/packages/urql/makeUrqlClient.js
@@ -30,10 +30,12 @@ export async function fetchGraphqlSchema (endpoint) {
 
 export default async function makeUrqlClient ({
   subscriptionExchange: providedSubscriptionExchange,
-  schemaAwareness = false
+  schemaAwareness = true // Enable by default to fix union type warnings
 } = {}) {
   const schema = schemaAwareness && await fetchGraphqlSchema(GRAPHQL_ENDPOINT_URL)
-  if (schema) console.log('URQL Schema Awareness turned on')
+  if (schema && process.env.NODE_ENV === 'development') {
+    console.log('URQL Schema Awareness turned on')
+  }
 
   const cache = cacheExchange({
     keys,
@@ -55,7 +57,9 @@ export default async function makeUrqlClient ({
       const response = await fetch(...args)
 
       if (response.headers.get('set-cookie')) {
-        console.log('!!! setting cookie in urql fetch', response.headers.get('set-cookie'))
+        if (process.env.NODE_ENV === 'development') {
+          console.log('!!! setting cookie in urql fetch', response.headers.get('set-cookie'))
+        }
         await setSessionCookie(response)
       }
 

--- a/packages/urql/updates/index.js
+++ b/packages/urql/updates/index.js
@@ -6,7 +6,304 @@ import { reactOn, deleteReaction } from './reactions'
 import { handleReactionPostCompletion } from './sideEffectPostCompletion'
 
 // Set to true to enable debug logging for group subscriptions
-const isDev = false
+const isDev = process.env.NODE_ENV === 'development'
+
+const subscriptionHandlers = {
+  updates: (result, args, cache, info) => {
+    const update = result?.updates
+
+    if (update) {
+      if (isDev) {
+        console.log('📱 Received notification update:', update.activity?.action || 'unknown action')
+      }
+
+      // For Messages and MessageThreads, handle differently
+      if (update.message) {
+        // This is a direct message
+        cache.invalidate({ __typename: 'Message', id: update.message.id })
+
+        // Invalidate the message thread
+        if (update.message.messageThread) {
+          cache.invalidate({ __typename: 'MessageThread', id: update.message.messageThread.id })
+        }
+
+        // Invalidate messageThreads query to update the list
+        const messageThreadsFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'messageThreads')
+        messageThreadsFields.forEach(field => {
+          cache.invalidate('Query', field.fieldKey)
+        })
+
+        // Update Me query to reflect new message count
+        cache.updateQuery({ query: meQuery }, ({ me }) => {
+          if (!me) return null
+          return {
+            me: {
+              ...me,
+              unseenThreadCount: me.unseenThreadCount + 1
+            }
+          }
+        })
+      } else if (update.messageThread) {
+        // This is a message thread update
+        cache.invalidate({ __typename: 'MessageThread', id: update.messageThread.id })
+
+        // Invalidate messageThreads query
+        const messageThreadsFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'messageThreads')
+        messageThreadsFields.forEach(field => {
+          cache.invalidate('Query', field.fieldKey)
+        })
+      } else if (update.notification) {
+        // This is a notification
+        cache.invalidate({ __typename: 'Notification', id: update.notification.id })
+
+        // Invalidate notifications query
+        const notificationsFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'notifications')
+        notificationsFields.forEach(field => {
+          cache.invalidate('Query', field.fieldKey)
+        })
+
+        // Update Me query to reflect new notification count
+        cache.updateQuery({ query: meQuery }, ({ me }) => {
+          if (!me) return null
+          return {
+            me: {
+              ...me,
+              newNotificationCount: me.newNotificationCount + 1
+            }
+          }
+        })
+      }
+    }
+  },
+
+  groupUpdates: (result, args, cache, info) => {
+    const update = result?.groupUpdates
+
+    if (update) {
+      if (isDev) {
+        console.log(`📱 Received group update: ${update.name} (${update.id})`)
+      }
+
+      // Invalidate the specific group
+      cache.invalidate({ __typename: 'Group', id: update.id })
+
+      // Find and invalidate any group queries for this specific group
+      const groupFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'group')
+      groupFields.forEach(field => {
+        // Check if this field is for the updated group
+        if (field.arguments?.id === update.id || field.arguments?.slug === update.slug) {
+          cache.invalidate('Query', field.fieldKey)
+        }
+      })
+
+      // Invalidate groups list queries
+      const groupsFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'groups')
+      groupsFields.forEach(field => {
+        cache.invalidate('Query', field.fieldKey)
+      })
+
+      // Update Me query to reflect any group changes
+      cache.updateQuery({ query: meQuery }, (data) => {
+        if (!data?.me) return null
+        // Force refetch of user's groups by invalidating
+        return data
+      })
+    }
+  },
+
+  groupMembershipUpdates: (result, args, cache, info) => {
+    const update = result?.groupMembershipUpdates
+
+    if (update) {
+      if (isDev) {
+        console.log(`📱 Received membership update: ${update.member.name} ${update.action} ${update.group.name}`)
+      }
+
+      // Invalidate the specific group to trigger membership refetch
+      cache.invalidate({ __typename: 'Group', id: update.group.id })
+
+      // Update Me query to reflect membership changes
+      cache.updateQuery({ query: meQuery }, (data) => {
+        if (!data?.me) return null
+
+        const { me } = data
+        const existingMemberships = me.memberships || []
+        if (update.action === 'joined' || update.action === 'rejoined') {
+          // Check if membership already exists
+          const existingMembership = existingMemberships.find(m => m.group.id === update.group.id)
+          if (!existingMembership) {
+            // Add new membership
+            const newMembership = {
+              __typename: 'GroupMembership',
+              id: `temp-${update.group.id}`, // Temporary ID
+              group: update.group,
+              role: update.role || 0,
+              hasModeratorRole: update.role === 1,
+              settings: {}
+            }
+            return {
+              me: {
+                ...me,
+                memberships: [...existingMemberships, newMembership]
+              }
+            }
+          }
+        } else if (update.action === 'left') {
+          // Remove membership
+          const filteredMemberships = existingMemberships.filter(m => m.group.id !== update.group.id)
+          return {
+            me: {
+              ...me,
+              memberships: filteredMemberships
+            }
+          }
+        }
+
+        return data
+      })
+
+      // Invalidate related group queries
+      const groupFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'group')
+      groupFields.forEach(field => {
+        if (field.arguments?.id === update.group.id || field.arguments?.slug === update.group.slug) {
+          cache.invalidate('Query', field.fieldKey)
+        }
+      })
+
+      // Invalidate groups list queries
+      const groupsFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'groups')
+      groupsFields.forEach(field => {
+        cache.invalidate('Query', field.fieldKey)
+      })
+    }
+  },
+
+  groupRelationshipUpdates: (result, args, cache, info) => {
+    const update = result?.groupRelationshipUpdates
+
+    if (update) {
+      if (isDev) {
+        console.log(`📱 Received relationship update: ${update.action} between ${update.parentGroup.name} and ${update.childGroup.name}`)
+      }
+
+      // Invalidate both groups involved in the relationship
+      cache.invalidate({ __typename: 'Group', id: update.parentGroup.id })
+      cache.invalidate({ __typename: 'Group', id: update.childGroup.id })
+
+      // Invalidate group queries for both groups
+      const groupFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'group')
+      groupFields.forEach(field => {
+        if (field.arguments?.id === update.parentGroup.id ||
+            field.arguments?.slug === update.parentGroup.slug ||
+            field.arguments?.id === update.childGroup.id ||
+            field.arguments?.slug === update.childGroup.slug) {
+          cache.invalidate('Query', field.fieldKey)
+        }
+      })
+
+      // Invalidate groups list queries
+      const groupsFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'groups')
+      groupsFields.forEach(field => {
+        cache.invalidate('Query', field.fieldKey)
+      })
+    }
+  },
+
+  postUpdates: (result, args, cache, info) => {
+    const update = result?.postUpdates
+
+    if (update) {
+      if (isDev) {
+        console.log(`📱 Received post update: ${update.name || 'Untitled'} (${update.id})`)
+      }
+
+      // Invalidate the specific post to trigger cache updates
+      cache.invalidate({ __typename: 'Post', id: update.id })
+
+      const allQueryFields = cache.inspectFields('Query')
+      const postDetailsQueries = allQueryFields.filter(f =>
+        f.fieldName === 'post' && f.arguments?.id === update.id
+      )
+      postDetailsQueries.forEach(field => {
+        cache.invalidate('Query', field.fieldKey)
+      })
+
+      const groupFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'group')
+      groupFields.forEach(field => {
+        cache.invalidate('Query', field.fieldKey)
+      })
+
+      // NOTE: Comment updates (adding/editing comments, reactions on comments) are handled
+      // by the separate 'comments' subscription, not postUpdates. The postUpdates subscription
+      // only handles post-level changes like reactions on posts, votes, completion, etc.
+      // See: apps/backend/api/graphql/makeSubscriptions.js -> comments subscription
+
+      const postsFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'posts')
+      postsFields.forEach(field => {
+        cache.invalidate('Query', field.fieldKey)
+      })
+    }
+  },
+
+  // UNIFIED SUBSCRIPTION HANDLER: Routes updates from allUpdates to appropriate handlers
+  allUpdates: (result, args, cache, info) => {
+    const update = result?.allUpdates
+    if (!update) return
+
+    // Route to existing handlers based on typename and content
+    const typename = update.__typename
+
+    if (isDev) {
+      console.log('📱 Unified subscription received update:', typename, update.id || update.name || 'unknown')
+    }
+
+    switch (typename) {
+      case 'Notification': {
+        // Handle as updates subscription
+        subscriptionHandlers.updates({ updates: update }, args, cache, info)
+        break
+      }
+
+      case 'Group': {
+        // Handle as groupUpdates subscription
+        subscriptionHandlers.groupUpdates({ groupUpdates: update }, args, cache, info)
+        break
+      }
+
+      case 'GroupMembershipUpdate': {
+        // Handle as groupMembershipUpdates subscription
+        subscriptionHandlers.groupMembershipUpdates({ groupMembershipUpdates: update }, args, cache, info)
+        break
+      }
+
+      case 'GroupRelationshipUpdate': {
+        // Handle as groupRelationshipUpdates subscription
+        subscriptionHandlers.groupRelationshipUpdates({ groupRelationshipUpdates: update }, args, cache, info)
+        break
+      }
+
+      case 'Post': {
+        // Handle as postUpdates subscription
+        subscriptionHandlers.postUpdates({ postUpdates: update }, args, cache, info)
+        break
+      }
+
+      case 'Comment': {
+        // Handle messages (Comments with makeModelsType = 'Message')
+        if (update.makeModelsType === 'Message') {
+          subscriptionHandlers.updates({ updates: { message: update } }, args, cache, info)
+        }
+        break
+      }
+
+      default: {
+        if (isDev) {
+          console.log('⚠️ Unhandled unified update type:', typename, update)
+        }
+      }
+    }
+  }
+}
 
 export default {
   Mutation: {
@@ -332,225 +629,7 @@ export default {
       }
     },
 
-    updates: (result, args, cache, info) => {
-      const update = result?.updates
-
-      switch (update?.__typename) {
-        case 'Message': {
-          makeAppendToPaginatedSetResolver({
-            parentType: 'MessageThread',
-            parentId: update?.messageThread?.id,
-            fieldName: 'messages'
-          })(result, args, cache, info)
-          cache.invalidate({ __typename: 'MessageThread', id: update?.messageThread?.id })
-          cache.updateQuery({ query: meQuery }, (data) => {
-            if (!data?.me) return null
-            const { me } = data
-            return { me: { ...me, unseenThreadCount: me.unseenThreadCount + 1 } }
-          })
-          return
-        }
-
-        case 'MessageThread': {
-          makeAppendToPaginatedSetResolver({
-            parentType: 'Me',
-            fieldName: 'messageThreads'
-          })(result, args, cache, info)
-          cache.updateQuery({ query: meQuery }, (data) => {
-            if (!data?.me) return null
-            const { me } = data
-            return { me: { ...me, unseenThreadCount: me.unseenThreadCount + 1 } }
-          })
-          return
-        }
-
-        case 'Notification': {
-          makeAppendToPaginatedSetResolver({
-            parentType: 'Query',
-            fieldName: 'notifications'
-          })(result, args, cache, info)
-          cache.updateQuery({ query: meQuery }, (data) => {
-            if (!data?.me) return null
-            const { me } = data
-            return { me: { ...me, newNotificationCount: me.newNotificationCount + 1 } }
-          })
-          return
-        }
-
-        default: {
-          console.log('ℹ️ Unhandled update from updates subscription', result, args)
-        }
-      }
-    },
-
-    groupUpdates: (result, args, cache, info) => {
-      const update = result?.groupUpdates
-
-      if (update) {
-        if (isDev) {
-          console.log(`📱 Received group update: ${update.name} (${update.id})`)
-        }
-
-        // Invalidate the specific group to trigger a refetch with updated data
-        cache.invalidate({ __typename: 'Group', id: update.id })
-
-        // Also invalidate any group queries that might include this group
-        const groupFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'group')
-        groupFields.forEach(field => {
-          // Check if this field is for the updated group
-          if (field.arguments?.id === update.id || field.arguments?.slug === update.slug) {
-            cache.invalidate('Query', field.fieldKey)
-          }
-        })
-
-        // Invalidate groups list queries
-        const groupsFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'groups')
-        groupsFields.forEach(field => {
-          cache.invalidate('Query', field.fieldKey)
-        })
-
-        // Update Me query to reflect any group changes
-        cache.updateQuery({ query: meQuery }, (data) => {
-          if (!data?.me) return null
-          // Force refetch of user's groups by invalidating
-          return data
-        })
-      }
-    },
-
-    groupMembershipUpdates: (result, args, cache, info) => {
-      const update = result?.groupMembershipUpdates
-
-      if (update) {
-        if (isDev) {
-          console.log(`📱 Received membership update: ${update.member.name} ${update.action} ${update.group.name}`)
-        }
-
-        // Invalidate the specific group to trigger membership refetch
-        cache.invalidate({ __typename: 'Group', id: update.group.id })
-
-        // Update Me query to reflect membership changes
-        cache.updateQuery({ query: meQuery }, (data) => {
-          if (!data?.me) return null
-
-          const { me } = data
-          const existingMemberships = me.memberships || []
-          if (update.action === 'joined' || update.action === 'rejoined') {
-            // Check if membership already exists
-            const existingMembership = existingMemberships.find(m => m.group.id === update.group.id)
-            if (!existingMembership) {
-              // Add new membership
-              const newMembership = {
-                __typename: 'GroupMembership',
-                id: `temp-${update.group.id}`, // Temporary ID
-                group: update.group,
-                role: update.role || 0,
-                hasModeratorRole: update.role === 1,
-                settings: {}
-              }
-              return {
-                me: {
-                  ...me,
-                  memberships: [...existingMemberships, newMembership]
-                }
-              }
-            }
-          } else if (update.action === 'left') {
-            // Remove membership
-            const filteredMemberships = existingMemberships.filter(m => m.group.id !== update.group.id)
-            return {
-              me: {
-                ...me,
-                memberships: filteredMemberships
-              }
-            }
-          }
-
-          return data
-        })
-
-        // Invalidate related group queries
-        const groupFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'group')
-        groupFields.forEach(field => {
-          if (field.arguments?.id === update.group.id || field.arguments?.slug === update.group.slug) {
-            cache.invalidate('Query', field.fieldKey)
-          }
-        })
-
-        // Invalidate groups list queries
-        const groupsFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'groups')
-        groupsFields.forEach(field => {
-          cache.invalidate('Query', field.fieldKey)
-        })
-      }
-    },
-
-    groupRelationshipUpdates: (result, args, cache, info) => {
-      const update = result?.groupRelationshipUpdates
-
-      if (update) {
-        if (isDev) {
-          console.log(`📱 Received relationship update: ${update.action} between ${update.parentGroup.name} and ${update.childGroup.name}`)
-        }
-
-        // Invalidate both groups involved in the relationship
-        cache.invalidate({ __typename: 'Group', id: update.parentGroup.id })
-        cache.invalidate({ __typename: 'Group', id: update.childGroup.id })
-
-        // Invalidate group queries for both groups
-        const groupFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'group')
-        groupFields.forEach(field => {
-          const groupId = field.arguments?.id
-          const groupSlug = field.arguments?.slug
-
-          if (groupId === update.parentGroup.id || groupId === update.childGroup.id ||
-              groupSlug === update.parentGroup.slug || groupSlug === update.childGroup.slug) {
-            cache.invalidate('Query', field.fieldKey)
-          }
-        })
-
-        // Invalidate groups list queries to reflect relationship changes
-        const groupsFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'groups')
-        groupsFields.forEach(field => {
-          cache.invalidate('Query', field.fieldKey)
-        })
-      }
-    },
-
-    postUpdates: (result, args, cache, info) => {
-      const update = result?.postUpdates
-
-      if (update) {
-        if (isDev) {
-          console.log(`📱 Received post update: ${update.name || 'Untitled'} (${update.id})`)
-        }
-
-        // Invalidate the specific post to trigger cache updates
-        cache.invalidate({ __typename: 'Post', id: update.id })
-
-        const allQueryFields = cache.inspectFields('Query')
-        const postDetailsQueries = allQueryFields.filter(f =>
-          f.fieldName === 'post' && f.arguments?.id === update.id
-        )
-        postDetailsQueries.forEach(field => {
-          cache.invalidate('Query', field.fieldKey)
-        })
-
-        const groupFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'group')
-        groupFields.forEach(field => {
-          cache.invalidate('Query', field.fieldKey)
-        })
-
-        // NOTE: Comment updates (adding/editing comments, reactions on comments) are handled
-        // by the separate 'comments' subscription, not postUpdates. The postUpdates subscription
-        // only handles post-level changes like reactions on posts, votes, completion, etc.
-        // See: apps/backend/api/graphql/makeSubscriptions.js -> comments subscription
-
-        const postsFields = cache.inspectFields('Query').filter((field) => field.fieldName === 'posts')
-        postsFields.forEach(field => {
-          cache.invalidate('Query', field.fieldKey)
-        })
-      }
-    }
+    // Use the subscription handlers defined above
+    ...subscriptionHandlers
   }
 }


### PR DESCRIPTION
Ok, after much debugging, it seemed that a silent connection limit was causing endless fetching on Android.

As a consequence, I have consolidated several subscriptions into a unified one. So we will have one main subscription, which will sync several different entities, and also a few context specific subscriptions, that only subscribe when specific screens are opened.