### PR TITLE
Web/chat room improvements

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -35,7 +35,7 @@
   </head>
   <body>
     <!-- if the value of 'root' is ever changed, than also change the value in /src/client/util -->
-    <div id="root"></div>
+    <div id="root" style="height: 100vh; height: 100dvh; overflow: hidden;"></div>
 
     <!--
       This HTML file is a template.

--- a/apps/web/public/locales/en.json
+++ b/apps/web/public/locales/en.json
@@ -635,6 +635,7 @@
   "New post at this location:": "New post at this location:",
   "New post in <strong>{{name}}</strong>": "New post in <strong>{{name}}</strong>",
   "New post in {{groupName}} <strong>{{name}}</strong>": "New post in {{groupName}} <strong>{{name}}</strong>",
+  "New posts": "New posts",
   "Next": "Next",
   "Next Action": "Next Action",
   "Next: Welcome to Hylo!": "Next: Welcome to Hylo!",

--- a/apps/web/public/locales/es.json
+++ b/apps/web/public/locales/es.json
@@ -637,6 +637,7 @@
   "New post at this location:": "Nueva publicación en esta ubicación:",
   "New post in <strong>{{name}}</strong>": "Nueva publicación en <strong>{{name}}</strong>",
   "New post in {{groupName}} <strong>{{name}}</strong>": "Nueva publicación en {{groupName}} <strong>{{name}}</strong>",
+  "New posts": "Nuevas publicaciones",
   "Next": "Próximo",
   "Next Action": "Siguiente acción",
   "Next: Welcome to Hylo!": "Siguiente: ¡Bienvenido a Hylo!",

--- a/apps/web/src/components/EmojiRow/EmojiRow.js
+++ b/apps/web/src/components/EmojiRow/EmojiRow.js
@@ -50,7 +50,6 @@ export default function EmojiRow (props) {
     <div className={cn('hover:scale-105 transition-all hover:z-10 mr-4 inline-block', className)} onClick={onClick}>
       {entityReactions && (
         <div className='transition-all duration-250 ease-in-out flex relative items-center flex-wrap'>
-          {currentUser ? <EmojiPicker handleReaction={handleReaction} myEmojis={myEmojis} handleRemoveReaction={handleRemoveReaction} onOpenChange={onOpenChange} /> : ''}
           {Object.values(usersReactions).map(reaction => (
             <EmojiPill
               onClick={currentUser ? reaction.loggedInUser ? handleRemoveReaction : handleReaction : null}
@@ -61,6 +60,7 @@ export default function EmojiRow (props) {
               toolTip={reaction.userList.join('<br>')}
             />
           ))}
+          {currentUser ? <EmojiPicker handleReaction={handleReaction} myEmojis={myEmojis} handleRemoveReaction={handleRemoveReaction} onOpenChange={onOpenChange} /> : ''}
         </div>
       )}
     </div>

--- a/apps/web/src/components/HyloEditor/HyloEditor.js
+++ b/apps/web/src/components/HyloEditor/HyloEditor.js
@@ -137,6 +137,11 @@ const HyloEditor = React.forwardRef(({
     Highlight
   ]
 
+  const onTouchMove = (e) => {
+    // Hide the keyboard when scrolling on mobile so you can't scroll down to empty white space on safari
+    editorRef.current.commands.blur()
+  }
+
   const editor = useEditor({
     content: contentHTML,
     extensions,
@@ -147,6 +152,12 @@ const HyloEditor = React.forwardRef(({
       // Don't call onUpdate until the editor is full initialized (including initial content added)
       if (!onUpdate || !initialized) return
       onUpdate(editor.getHTML())
+    },
+    onFocus: () => {
+      document.addEventListener('touchmove', onTouchMove, { passive: false })
+    },
+    onBlur: () => {
+      document.removeEventListener('touchmove', onTouchMove, { passive: false })
     }
   })
 
@@ -178,15 +189,9 @@ const HyloEditor = React.forwardRef(({
     editor.setEditable(!readOnly)
   }, [readOnly])
 
-  const onTouchMove = (e) => {
-    editorRef.current.commands.blur()
-    e.preventDefault()
-  }
-
   useImperativeHandle(ref, () => ({
     blur: () => {
       editorRef.current.commands.blur()
-      document.removeEventListener('touchmove', onTouchMove)
     },
     clearContent: () => {
       // `true` here means it will emit an `onUpdate`
@@ -194,9 +199,8 @@ const HyloEditor = React.forwardRef(({
     },
     focus: position => {
       if (editorRef.current) {
-        editorRef.current.commands.focus(position)
+        editorRef.current.commands.focus(position || 'start')
       }
-      document.addEventListener('touchmove', onTouchMove)
     },
     getHTML: () => {
       return editorRef.current.getHTML()

--- a/apps/web/src/components/PostCard/PostContent/PostContent.jsx
+++ b/apps/web/src/components/PostCard/PostContent/PostContent.jsx
@@ -56,7 +56,7 @@ export default function PostContent ({
             {editedTimestamp}
           </div>
         )}
-        <div className='flex flex-col gap-4 mt-6'>
+        <div className='flex flex-col gap-4'>
           {linkPreview && !linkPreviewFeatured && (
             <LinkPreview {...pick(['title', 'description', 'url', 'imageUrl'], linkPreview)} />
           )}

--- a/apps/web/src/components/PostEditor/PostEditor.js
+++ b/apps/web/src/components/PostEditor/PostEditor.js
@@ -295,7 +295,9 @@ function PostEditor ({
 
   useEffect(() => {
     if (isChat) {
-      setTimeout(() => { editorRef.current && editorRef.current.focus() }, 100)
+      setTimeout(() => {
+        editorRef.current && editorRef.current.focus()
+      }, 500)
     } else {
       setTimeout(() => { titleInputRef.current && titleInputRef.current.focus() }, 100)
     }
@@ -350,7 +352,9 @@ function PostEditor ({
     setAnnouncementSelected(false)
     setShowAnnouncementModal(false)
     if (isChat) {
-      setTimeout(() => { editorRef.current && editorRef.current.focus() }, 100)
+      setTimeout(() => {
+        editorRef.current && editorRef.current.focus()
+      }, 500)
     } else {
       toFieldRef?.current?.reset()
       setTimeout(() => { titleInputRef.current && titleInputRef.current.focus() }, 100)

--- a/apps/web/src/routes/AuthLayoutRouter/AuthLayoutRouter.js
+++ b/apps/web/src/routes/AuthLayoutRouter/AuthLayoutRouter.js
@@ -3,7 +3,6 @@ import { matchPath, Route, Routes, Navigate, useLocation, useNavigate } from 're
 import { useDispatch, useSelector } from 'react-redux'
 import { IntercomProvider } from 'react-use-intercom'
 import { Helmet } from 'react-helmet'
-import Div100vh from 'react-div-100vh'
 import { get, some } from 'lodash/fp'
 import { cn } from 'util/index'
 import mixpanel from 'mixpanel-browser'
@@ -263,7 +262,7 @@ export default function AuthLayoutRouter (props) {
         )}
       </Routes>
 
-      <Div100vh className={cn('flex flex-row items-stretch bg-midground', { [classes.mapView]: isMapView, [classes.detailOpen]: hasDetail })}>
+      <div className={cn('flex flex-row items-stretch bg-midground h-[100vh] h-[100dvh]', { [classes.mapView]: isMapView, [classes.detailOpen]: hasDetail })}>
         <div ref={resizeRef} className={cn(classes.main, { [classes.mapView]: isMapView, [classes.withoutNav]: withoutNav, [classes.mainPad]: !withoutNav })}>
           <div className={cn('AuthLayoutRouterNavContainer hidden sm:flex flex-row max-w-420 h-full z-50', { 'flex absolute sm:relative': isNavOpen })}>
             {!withoutNav && (
@@ -466,7 +465,7 @@ export default function AuthLayoutRouter (props) {
           </div>
         </div>
         <CookieConsentLinker />
-      </Div100vh>
+      </div>
     </IntercomProvider>
   )
 }

--- a/apps/web/src/routes/AuthLayoutRouter/AuthLayoutRouter.module.scss
+++ b/apps/web/src/routes/AuthLayoutRouter/AuthLayoutRouter.module.scss
@@ -1,4 +1,6 @@
-body {
+html, body {
+  height: 100vh; /* fallback */
+  height: 100dvh;
   overflow: hidden;
 }
 

--- a/apps/web/src/routes/AuthLayoutRouter/components/GlobalNav/NotificationsDropdown/NotificationsDropdown.jsx
+++ b/apps/web/src/routes/AuthLayoutRouter/components/GlobalNav/NotificationsDropdown/NotificationsDropdown.jsx
@@ -43,7 +43,7 @@ function NotificationsDropdown ({ renderToggleChildren, className }) {
     setTimeout(() => {
       const container = document.getElementById('notifications-scroll-list')
       if (container) {
-        container.addEventListener('wheel', (e) => { console.log('wheel event', e); e.stopPropagation() }, { passive: false })
+        container.addEventListener('wheel', (e) => { e.stopPropagation() }, { passive: false })
       }
     }, 100)
   }, [modalOpen])

--- a/apps/web/src/routes/ChatRoom/ChatPost/ChatPost.js
+++ b/apps/web/src/routes/ChatRoom/ChatPost/ChatPost.js
@@ -226,12 +226,13 @@ export default function ChatPost ({
     <Highlight {...highlightProps}>
       <div
         className={cn(
-          'ChatPost_container rounded-lg pr-[15px] pb-[1px] mb-1 relative hover:bg-background transition-all group hover:shadow-lg hover:cursor-pointer',
+          'ChatPost_container rounded-lg pr-[15px] pb-[1px] mb-1 relative transition-all group cursor-pointer',
           className,
           styles.container,
           {
             [styles.longPressed]: isLongPress,
             [styles.hovered]: isHovered,
+            'bg-background shadow-lg': isHovered,
             'bg-accent/30': highlighted
           }
         )}
@@ -240,7 +241,15 @@ export default function ChatPost ({
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
       >
-        <div className='flex p-1 gap-2 absolute z-10 right-2 -top-1 transition-all rounded-lg bg-theme-background opacity-0 group-hover:opacity-100 delay-300 scale-0 group-hover:scale-100'>
+        <div className={
+          cn(
+            'flex p-1 gap-2 absolute z-10 right-2 -top-1 transition-all rounded-lg bg-theme-background opacity-0 delay-100 scale-0',
+            {
+              'opacity-100 scale-100 scale-100': isHovered
+            }
+          )
+          }
+        >
           {actionItems.map(item => (
             <button
               key={item.label}

--- a/apps/web/src/routes/ChatRoom/ChatPost/ChatPost.js
+++ b/apps/web/src/routes/ChatRoom/ChatPost/ChatPost.js
@@ -226,7 +226,7 @@ export default function ChatPost ({
     <Highlight {...highlightProps}>
       <div
         className={cn(
-          'ChatPost_container rounded-lg pr-[15px] relative hover:bg-background transition-all group hover:shadow-lg hover:cursor-pointer mb-1',
+          'ChatPost_container rounded-lg pr-[15px] pb-[1px] mb-1 relative hover:bg-background transition-all group hover:shadow-lg hover:cursor-pointer',
           className,
           styles.container,
           {
@@ -251,7 +251,7 @@ export default function ChatPost ({
             </button>
           ))}
           <EmojiPicker
-            className='w-6 h-6 flex justify-center items-center rounded-lg bg-midground/20 hover:scale-110 transition-all hover:bg-midground/100 shadow-lg hover:cursor-pointer'
+            className='w-6 h-6 flex justify-center items-center rounded-lg bg-midground/20 transition-all hover:bg-midground/100 shadow-lg hover:cursor-pointer'
             handleReaction={handleReaction}
             handleRemoveReaction={handleRemoveReaction}
             myEmojis={myEmojis}
@@ -314,20 +314,24 @@ export default function ChatPost ({
         {!isEmpty(fileAttachments) && (
           <CardFileAttachments attachments={fileAttachments} />
         )}
-        <EmojiRow
-          className={cn(styles.emojis, { [styles.noEmojis]: !postReactions || postReactions.length === 0 })}
-          post={post}
-          currentUser={currentUser}
-          onAddReaction={onAddReaction}
-          onRemoveReaction={onRemoveReaction}
-        />
+        <div className='w-full' onClick={handleClick}>
+          <EmojiRow
+            className={cn(styles.emojis, { [styles.noEmojis]: !postReactions || postReactions.length === 0 })}
+            post={post}
+            currentUser={currentUser}
+            onAddReaction={onAddReaction}
+            onRemoveReaction={onRemoveReaction}
+          />
+        </div>
         {commentsTotal > 0 && (
-          <span className='bg-black/10 rounded-lg py-2 px-2 h-[40px] items-center justify-center flex w-[120px]'>
-            <RoundImageRow imageUrls={commenterAvatarUrls.slice(0, 3)} className={styles.commenters} onClick={handleClick} small />
-            <span className='text-sm text-foreground' onClick={handleClick}>
-              {commentsTotal} {commentsTotal === 1 ? 'reply' : 'replies'}
+          <div className='w-full' onClick={handleClick}>
+            <span className='ChatPost_commenters bg-black/10 rounded-lg py-2 px-2 ml-[40px] xs:ml-[48px] h-[40px] mb-[2px] items-center justify-center flex w-[120px]'>
+              <RoundImageRow imageUrls={commenterAvatarUrls.slice(0, 3)} className={styles.commenters} onClick={handleClick} small />
+              <span className='text-sm text-foreground' onClick={handleClick}>
+                {commentsTotal} {commentsTotal === 1 ? 'reply' : 'replies'}
+              </span>
             </span>
-          </span>
+          </div>
         )}
       </div>
     </Highlight>

--- a/apps/web/src/routes/ChatRoom/ChatPost/ChatPost.module.scss
+++ b/apps/web/src/routes/ChatRoom/ChatPost/ChatPost.module.scss
@@ -163,7 +163,8 @@
 }
 
 .emojis {
-  margin-left: 23px;
+  margin-left: 44px;
+  margin-bottom: 2px;
 }
 
 .noEmojis {
@@ -197,7 +198,7 @@
   filter: blur(4px);
 }
 
-@media screen and (max-width: 600px) {
+@media screen and (max-width: 640px) {
   .container {
     padding-left: 15px;
 
@@ -238,22 +239,18 @@
 }
 
 
-@media screen and (max-width: 425px) {
+@media screen and (max-width: 410px) {
   .postContentContainer {
-    margin-left: 39px;
+    margin-left: 35px;
+  }
+
+  .emojis {
+    margin-left: 37px;
   }
 
   .container {
     -webkit-user-select: none; /* disable selection/Copy of UIWebView */
     user-select: none;
     -webkit-touch-callout: none; /* disable the IOS popup when long-press on a link */
-  }
-}
-
-@media screen and (max-width: 375px) {
-
-  .postContent {
-    font-size: 12px;
-    line-height: 16px;
   }
 }

--- a/apps/web/src/routes/ChatRoom/ChatRoom.js
+++ b/apps/web/src/routes/ChatRoom/ChatRoom.js
@@ -123,7 +123,6 @@ export default function ChatRoom (props) {
   const [postIdToStartAt, setPostIdToStartAt] = useState(querystringParams?.postId)
 
   const [container, setContainer] = React.useState(null)
-  const editorRef = useRef()
   const messageListRef = useRef(null)
 
   // The last post seen by the current user. Doesn't update in real time as they scroll only when room is reloaded
@@ -323,13 +322,6 @@ export default function ChatRoom (props) {
       // Reset marker of new posts
       setLatestOldPostId(topicFollow.lastReadPostId)
     }
-
-    setTimeout(() => {
-      // In case we unmounted really quick and its no longer here
-      if (editorRef.current) {
-        editorRef.current.focus()
-      }
-    }, 1000)
   }, [topicFollow?.id])
 
   // Do once after loading posts for the room to get things ready
@@ -523,8 +515,6 @@ export default function ChatRoom (props) {
         return 'auto'
       }
     })
-    // Focus back on the chat box
-    editorRef.current?.focus()
     return true
   }, [])
 

--- a/apps/web/src/routes/ChatRoom/ChatRoom.js
+++ b/apps/web/src/routes/ChatRoom/ChatRoom.js
@@ -686,6 +686,7 @@ const StickyFooter = ({ context }) => {
 }
 
 const ItemContent = ({ data: post, context, prevData, nextData, index }) => {
+  const { t } = useTranslation()
   const expanded = context.selectedPostId === post.id
   const highlighted = post.id && context.postIdToStartAt === post.id
   const firstUnread = context.latestOldPostId === prevData?.id && post.creator.id !== context.currentUser.id

--- a/apps/web/src/routes/ChatRoom/ChatRoom.js
+++ b/apps/web/src/routes/ChatRoom/ChatRoom.js
@@ -141,14 +141,15 @@ export default function ChatRoom (props) {
   // Add this new state to track if initial animation is complete
   const [initialAnimationComplete, setInitialAnimationComplete] = useState(false)
 
-  const numPostsToLoad = isWebView() || isMobile.any ? 18 : 30
+  // The number of posts that should fill a screen plus a few more to make sure we have enough posts to scroll through
+  const INITIAL_POSTS_TO_LOAD = isWebView() || isMobile.any ? 18 : 30
 
   const fetchPostsPastParams = useMemo(() => ({
     childPostInclusion: 'no',
     context,
     cursor: postIdToStartAt ? parseInt(postIdToStartAt) + 1 : parseInt(topicFollow?.lastReadPostId) + 1, // -1 because we want the lastread post id included
     filter: 'chat',
-    first: numPostsToLoad,
+    first: Math.max(INITIAL_POSTS_TO_LOAD - topicFollow?.newPostCount, 3), // Always load at least 3 past posts
     order: 'desc',
     slug: groupSlug,
     search,
@@ -161,7 +162,7 @@ export default function ChatRoom (props) {
     context,
     cursor: postIdToStartAt || topicFollow?.lastReadPostId,
     filter: 'chat',
-    first: numPostsToLoad,
+    first: Math.min(INITIAL_POSTS_TO_LOAD, topicFollow?.newPostCount),
     order: 'asc',
     slug: groupSlug,
     search,
@@ -207,8 +208,26 @@ export default function ChatRoom (props) {
       } else {
         messageListRef.current?.data.append(newPosts || [])
       }
+      return newPosts.length
     })
   }, [fetchPostsFutureParams, loadingFuture, hasMorePostsFuture])
+
+  const loadToLatest = useCallback(async () => {
+    // If there are many new posts, reset to newest using the existing reset flow
+    if ((topicFollow?.newPostCount || 0) >= INITIAL_POSTS_TO_LOAD * 2) {
+      // Set a huge postId to trigger the reset effect to fetch around the newest posts
+      dispatch(changeQuerystringParam(location, 'postId', String(Number.MAX_SAFE_INTEGER), null, true))
+      return
+    }
+
+    let offset = (postsFuture && postsFuture.length) ? postsFuture.length : 0
+    // Incrementally fetch remaining future pages
+    while (true) {
+      const fetched = await fetchPostsFuture(offset, { first: INITIAL_POSTS_TO_LOAD }, true)
+      if (!fetched || fetched < INITIAL_POSTS_TO_LOAD) break
+      offset += fetched
+    }
+  }, [dispatch, location, topicFollow?.newPostCount, fetchPostsFuture, postsFuture?.length])
 
   const handleNewPostReceived = useCallback((data) => {
     if (!data.topics?.find(t => t.name === topicName)) return
@@ -250,7 +269,8 @@ export default function ChatRoom (props) {
       } else {
         const postToScrollToIndex = postsForDisplay.findIndex(post => post.id === postToScrollTo)
         if (postToScrollToIndex !== -1) {
-          setInitialPostToScrollTo(postToScrollToIndex)
+          // Scroll to one before the post to scroll to, so the post is at the top of the screen and we can see one post of context
+          setInitialPostToScrollTo(Math.max(postToScrollToIndex - 1, 0))
         } else {
           // XXX: When joining a room we set the lastReadPostId to the largest post id in the database as a hack to bring people to the most recent post when they join a chat room
           // But more posts could have been added since we did this, so we if we can't find the last read post id, we scroll to the most recent post
@@ -260,7 +280,7 @@ export default function ChatRoom (props) {
     } else {
       setInitialPostToScrollTo(null)
     }
-  }, [loadedPast, loadedFuture, postsPast, postsFuture, postIdToStartAt])
+  }, [loadedPast, loadedFuture, postsForDisplay, postIdToStartAt])
 
   useEffect(() => {
     // Load TopicFollow
@@ -280,7 +300,16 @@ export default function ChatRoom (props) {
     if (topicFollow?.id) {
       setLoadedFuture(false)
       setNotificationsSetting(topicFollow?.settings?.notifications)
-      fetchPostsFuture(0).then(() => setLoadedFuture(true))
+
+      messageListRef.current?.data.replace([], {
+        purgeItemSizes: true
+      })
+
+      if (topicFollow.newPostCount > 0) {
+        fetchPostsFuture(0).then(() => setLoadedFuture(true))
+      } else {
+        setLoadedFuture(true)
+      }
 
       if (topicFollow.lastReadPostId) {
         setLoadedPast(false)
@@ -322,9 +351,9 @@ export default function ChatRoom (props) {
   useEffect(() => {
     if (querystringParams?.postId) {
       setPostIdToStartAt(querystringParams?.postId)
-      const index = postsForDisplay.findIndex(post => post.id === querystringParams?.postId)
+      const index = messageListRef.current?.data.findIndex(post => post.id === querystringParams?.postId)
       if (index !== -1) {
-        messageListRef.current?.scrollToItem({ index, align: 'end', behavior: 'auto' })
+        messageListRef.current?.scrollToItem({ index, align: 'start-no-overflow', behavior: 'auto' })
       } else if (loadedFuture && loadedPast) {
         // Can't find the post in the list, so we need to load a new set of posts around the one we want to scroll to
         // Basically just reset the list
@@ -337,15 +366,18 @@ export default function ChatRoom (props) {
         setLoadedFuture(false)
         setLoadedPast(false)
 
+        messageListRef.current?.data.replace([], {
+          purgeItemSizes: true
+        })
+
         // Load new data centered around the target post
         Promise.all([
-          fetchPostsFuture(0, { cursor: querystringParams?.postId }, true)
+          // We don't know how many posts are before or after the target post, so we load the initial number of posts to fill the screen
+          fetchPostsFuture(0, { cursor: querystringParams?.postId, first: INITIAL_POSTS_TO_LOAD }, true)
             .then(() => setLoadedFuture(true)),
-          fetchPostsPast(0, { cursor: parseInt(querystringParams?.postId) + 1 }, true)
+          fetchPostsPast(0, { cursor: parseInt(querystringParams?.postId) + 1, first: INITIAL_POSTS_TO_LOAD }, true)
             .then(() => setLoadedPast(true))
-        ]).then(() => {
-          resetInitialPostToScrollTo()
-        })
+        ])
       }
 
       // Remove the scroll to post from the url so we can click on a notification to scroll to it again
@@ -357,9 +389,9 @@ export default function ChatRoom (props) {
     () => debounce(200, (location) => {
       if (!loadingPast && !loadingFuture) {
         if (location.listOffset > -100 && hasMorePostsPast) {
-          fetchPostsPast(postsPast.length)
+          fetchPostsPast(postsPast.length, { first: 10 })
         } else if (location.bottomOffset < 50 && hasMorePostsFuture) {
-          fetchPostsFuture(postsFuture.length)
+          fetchPostsFuture(postsFuture.length, { first: 10 })
         }
       }
     }),
@@ -541,8 +573,6 @@ export default function ChatRoom (props) {
     })
   }, [topicName, notificationsSetting])
 
-  if (initialPostToScrollTo === null || topicFollowLoading) return <Loading />
-
   return (
     <div className={cn('h-full shadow-md flex flex-col overflow-hidden items-center justify-center px-1', { [styles.withoutNav]: withoutNav })} ref={setContainer}>
       <Helmet>
@@ -550,8 +580,8 @@ export default function ChatRoom (props) {
       </Helmet>
 
       <div id='chats' className='my-0 mx-auto h-[calc(100%-130px)] w-full flex flex-col flex-1 relative overflow-hidden'>
-        {initialPostToScrollTo === null
-          ? <div className={styles.loadingContainer}><Loading /></div>
+        {initialPostToScrollTo === null || topicFollowLoading
+          ? <div style={{ height: '100%', width: '100%', marginTop: 'auto', overflowX: 'hidden' }}><Loading /></div>
           : (
             <VirtuosoMessageListLicense licenseKey='0cd4e64293a1f6d3ef7a76bbd270d94aTzoyMztFOjE3NjI0NzIyMjgzMzM='>
               <VirtuosoMessageList
@@ -573,12 +603,13 @@ export default function ChatRoom (props) {
                   onAddProposalVote,
                   onRemoveProposalVote,
                   onSwapProposalVote,
+                  loadToLatest,
                   postIdToStartAt,
                   selectedPostId,
                   topicName
                 }}
                 initialData={postsForDisplay}
-                initialLocation={{ index: initialPostToScrollTo, align: initialPostToScrollTo === 0 ? 'start' : 'end' }}
+                initialLocation={{ index: initialPostToScrollTo, align: 'start-no-overflow' }}
                 shortSizeAlign='bottom-smooth'
                 computeItemKey={({ data }) => data.id || data.localId}
                 onScroll={onScroll}
@@ -658,12 +689,16 @@ const StickyFooter = ({ context }) => {
         right: 50
       }}
     >
-      {location.bottomOffset > 200 && (
+      {(location.bottomOffset > 200 || context.newPostCount > 0) && (
         <>
           <button
-            className='relative flex items-center justify-center bg-background border-2 border-foreground/15 rounded-full w-8 h-8 text-foreground/50 hover:bg-foreground/10 hover:text-foreground'
+            className='relative flex items-center justify-center bg-background border-2 border-foreground/15 rounded-full w-8 h-8 text-foreground/50 hover:text-foreground'
             onClick={() => {
-              virtuosoMethods.scrollToItem({ index: 'LAST', align: 'end', behavior: 'auto' })
+              // Ensure the newest posts are loaded before scrolling
+              Promise.resolve(context.loadToLatest?.())
+                .then(() => {
+                  virtuosoMethods.scrollToItem({ index: 'LAST', align: 'end', behavior: 'auto' })
+                })
             }}
             data-tooltip-content='Jump to latest post'
             data-tooltip-id='jump-to-bottom-tt'

--- a/apps/web/src/routes/ChatRoom/ChatRoom.js
+++ b/apps/web/src/routes/ChatRoom/ChatRoom.js
@@ -714,7 +714,7 @@ const ItemContent = ({ data: post, context, prevData, nextData, index }) => {
 
   return (
     <>
-      {firstUnread && !displayDay && <div className={styles.firstUnread}><hr className='border-t-2 border-red-500' /></div>}
+      {firstUnread && !displayDay && <div className={styles.firstUnread}><hr className='border-t-2 border-red-500' /> <span className='text-red-500 text-center w-full block'>{t('New posts')}</span></div>}
       {firstUnread && displayDay &&
         <div className={styles.unreadAndDay}>
           <hr className='border-t-2 border-red-500' />

--- a/apps/web/src/routes/ChatRoom/ChatRoom.js
+++ b/apps/web/src/routes/ChatRoom/ChatRoom.js
@@ -657,7 +657,7 @@ const EmptyPlaceholder = ({ context }) => {
 }
 
 const Header = ({ context }) => {
-  return context.loadingPast ? <div style={{ height: '30px' }}><Loading /></div> : null
+  return context.loadingPast ? <div className='absolute top-1 flex items-center justify-center w-full h-[30px]'><Loading /></div> : null
 }
 
 const Footer = ({ context }) => {

--- a/apps/web/src/routes/ChatRoom/ChatRoom.module.scss
+++ b/apps/web/src/routes/ChatRoom/ChatRoom.module.scss
@@ -26,7 +26,7 @@
   width: 100%;
   position: relative;
   padding: 30px 0 30px 0;
-  text-transform: uppercase;
+  font-size: .8rem
 }
 
 

--- a/apps/web/src/store/actions/fetchPosts.js
+++ b/apps/web/src/store/actions/fetchPosts.js
@@ -104,12 +104,6 @@ const groupQuery = childPostInclusion => `query GroupPostsQuery (
     id
     slug
     name
-    locationObject {
-      center {
-        lat
-        lng
-      }
-    }
     avatarUrl
     bannerUrl
     ${groupViewPostsQueryFragment(childPostInclusion)}


### PR DESCRIPTION
 Fix scroll jumping while scrolling up in chat room
Emoji picker doesnt jump around when hovering over it for chat post
 Line up emojis and replies with chat post content
 Tweak padding of it all.  
Clicking to right of emoji or replies row opens post as expected.
Use newPostCount to determine how many past and future posts we actually need to load - improving performance.
button to jump to latest actually does so when there are lots of new posts    
when loading chat room the new posts now start at the top of the screen instead of below the bottom of the screen.    
Load less posts at a time as you scroll so that should be faster    
Loading spinner in the middle of the chat room.
Add "New posts" text to new post line in chat room
