### PR TITLE
disable calendar view mode for phones

### DIFF
--- a/apps/web/src/components/StreamViewControls/StreamViewControls.js
+++ b/apps/web/src/components/StreamViewControls/StreamViewControls.js
@@ -1,4 +1,5 @@
 import { ArrowDownWideNarrow } from 'lucide-react'
+import isMobile from 'ismobilejs'
 import React, { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLocation } from 'react-router-dom'
@@ -169,7 +170,7 @@ const StreamViewControls = ({
             <Icon name='SmallGridView' className={classes.gridViewIcon} />
           </div>
 
-          {postHasDates && (
+          {postHasDates && !isMobile.any && (
             <div
               className={cn('rounded bg-midground shadow-sm px-1 cursor-pointer hover:bg-selected/50 hover:scale-125 transition-all items-center flex h-full', { 'bg-selected': viewMode === 'calendar' }, classes.calendar)}
               onClick={() => changeView('calendar')}

--- a/apps/web/src/routes/Stream/Stream.js
+++ b/apps/web/src/routes/Stream/Stream.js
@@ -104,7 +104,8 @@ export default function Stream (props) {
   if (view === 'events') {
     sortBy = 'start_time'
   }
-  const viewMode = querystringParams.v || customView?.defaultViewMode || defaultViewMode
+  const defViewMode = querystringParams.v || customView?.defaultViewMode || defaultViewMode
+  const viewMode = defViewMode === 'calendar' && isMobile.any ? 'list' : defViewMode
   const activePostsOnly = querystringParams.activeOnly === 'true' || (customView?.type === 'stream' && customView.activePostsOnly) || defaultActivePostsOnly
   const childPostInclusion = querystringParams.c || defaultChildPostInclusion
   const timeframe = querystringParams.timeframe || 'future'


### PR DESCRIPTION
Closes #1124 

Simple fix: disable calendar mode for small screens (isMobile.any) with minimal code change.