### PR TITLE
Fix translation sort: uppercase before lowercase

### DIFF
--- a/scripts/i18n/lib.js
+++ b/scripts/i18n/lib.js
@@ -27,7 +27,7 @@ function sortLocaleDeep (value) {
       return lowerA.localeCompare(lowerB)
     }
     // If case-insensitive equal, uppercase comes before lowercase
-    return a.localeCompare(b, undefined, { sensitivity: 'case' })
+    return b.localeCompare(a, undefined, { sensitivity: 'case' })
   })) {
     sorted[key] = sortLocaleDeep(value[key])
   }

--- a/scripts/i18n/lib.test.js
+++ b/scripts/i18n/lib.test.js
@@ -1,0 +1,34 @@
+const { sortLocaleDeep } = require('./lib')
+
+describe('sortLocaleDeep', () => {
+  it('sorts keys case-insensitively', () => {
+    const input = { banana: 1, apple: 2, cherry: 3 }
+    const keys = Object.keys(sortLocaleDeep(input))
+    expect(keys).toEqual(['apple', 'banana', 'cherry'])
+  })
+
+  it('sorts uppercase before lowercase when case-insensitive equal', () => {
+    const input = { b: 1, A: 2, a: 3, B: 4 }
+    const keys = Object.keys(sortLocaleDeep(input))
+    expect(keys).toEqual(['A', 'a', 'B', 'b'])
+  })
+
+  it('sorts nested objects recursively', () => {
+    const input = { z: { b: 1, a: 2 }, a: 3 }
+    const result = sortLocaleDeep(input)
+    expect(Object.keys(result)).toEqual(['a', 'z'])
+    expect(Object.keys(result.z)).toEqual(['a', 'b'])
+  })
+
+  it('returns non-object values unchanged', () => {
+    expect(sortLocaleDeep('hello')).toBe('hello')
+    expect(sortLocaleDeep(42)).toBe(42)
+    expect(sortLocaleDeep(null)).toBe(null)
+  })
+
+  it('handles arrays by sorting objects within them', () => {
+    const input = [{ b: 1, a: 2 }]
+    const result = sortLocaleDeep(input)
+    expect(Object.keys(result[0])).toEqual(['a', 'b'])
+  })
+})


### PR DESCRIPTION
Closes #1266

## Summary
- Fix `sortLocaleDeep` in `scripts/i18n/lib.js` to sort uppercase keys before lowercase when case-insensitive equal (e.g., `Save` before `save`)
- The `localeCompare` operands were in the wrong order, producing the opposite of the intended behavior
- Add unit tests for `sortLocaleDeep`

## Test plan
- [x] `npx jest scripts/i18n/lib.test.js` — 5 tests pass
- [x] Verified with realistic i18n keys (`Save`/`save`, `Search`/`search`) that uppercase sorts first

🤖 Generated with [Claude Code](https://claude.com/claude-code)