### PR TITLE
fix(ios): exclude /oauth/* from Universal Links so OIDC clients can complete sign-in

### DIFF
--- a/apps/web/public/apple-app-site-association
+++ b/apps/web/public/apple-app-site-association
@@ -16,6 +16,11 @@
                         "comment": "Exclude all other /noo/* paths"
                     },
                     {
+                        "/": "/oauth/*",
+                        "exclude": true,
+                        "comment": "Exclude the OIDC/OAuth login UI so third-party OIDC clients (e.g. castalia) can complete sign-in in the browser instead of being hijacked into the native app"
+                    },
+                    {
                         "/": "*"
                     }
                 ]


### PR DESCRIPTION
## Problem

Third-party OIDC clients (e.g. [Castalia](https://castalia.one), which uses Hylo as an OIDC provider via `/noo/oauth/auth`) can't complete sign-in on mobile because the Hylo native app universal-link-hijacks the OAuth login redirect.

### Flow that currently breaks on mobile (iOS)

1. Third-party app → user redirected to `https://www.hylo.com/noo/oauth/auth?...`
2. `/noo/oauth/auth` is correctly **excluded** from the current AASA (under the `/noo/*` exclude rule) ✅
3. Hylo's OIDC server 303s to `/noo/oidc/interaction/{id}` — also excluded ✅
4. That page redirects the browser to **`/oauth/login/{id}?name=<ClientName>`** ← the interactive login UI
5. `/oauth/login/*` is **not** matched by `/noo/*`, so it falls through to the `"/": "*"` catch-all → **iOS opens the Hylo app instead of showing the login page**
6. The native app doesn't have a handler for the OAuth login route, so the user is stranded and the OAuth flow never completes.

Observed error on the user side after returning to the browser:

> `This api.hylo.com page can't be found` / `HTTP ERROR 404`
> (or an effectively hung "Redirecting to Hylo…" page in the OIDC client)

## Fix

Add one more exclusion entry to the AASA before the `"/": "*"` catch-all:

```json
{
    "/": "/oauth/*",
    "exclude": true,
    "comment": "Exclude the OIDC/OAuth login UI so third-party OIDC clients can complete sign-in in the browser instead of being hijacked into the native app"
}
```

This leaves every existing deep-link path still claimed by the app — only the third-party OAuth consent/login surface is handed to the browser.

## Scope

- ✅ iOS AASA fix (this PR): `apps/web/public/apple-app-site-association`
- ⚠️ **Android is not covered by this PR.** `apps/web/public/.well-known/assetlinks.json` uses `delegate_permission/common.handle_all_urls`, which claims every URL on `www.hylo.com` with no path filter. Android App Links intent filters don't support path *exclusions*, only *inclusions* via `android:pathPrefix`/`android:pathPattern`. A proper Android fix requires enumerating the paths the Hylo Android app actually handles and replacing the current broad intent filter in `apps/mobile/android/app/src/main/AndroidManifest.xml` with path-scoped ones — this needs mobile-team knowledge of the app's deep-link surface, so I'm leaving it as a follow-up issue rather than guessing here.

## Verification

Tested the underlying chain against the running `www.hylo.com`:

```
$ curl -sS -D - "https://www.hylo.com/noo/oauth/auth?client_id=…&response_type=code&…&code_challenge=…&code_challenge_method=S256" | head -3
HTTP/1.1 303 See Other
Location: /noo/oidc/interaction/XXX

$ curl -sS -o /dev/null -w "%{http_code}\n" "https://www.hylo.com/oauth/login/test?name=Test"
200   # ← currently AASA-claimed because of "/": "*"
```

After this patch, iOS Universal Links stop intercepting `/oauth/login/*` and the browser renders the page as intended.

## Background

The fix was developed while debugging an infinite login-reload loop on mobile for https://calendar.castalia.one (a third-party OIDC consumer of Hylo). The current AASA already correctly excludes every `/noo/*` path so the OAuth *protocol* endpoints work — this PR just extends the same pattern to the *user-facing* OAuth page at `/oauth/*`.