### PR TITLE
1340 reset password crashout

### DIFF
--- a/apps/mobile/CHANGELOG
+++ b/apps/mobile/CHANGELOG
@@ -4,6 +4,9 @@ All notable changes to HyloReactNative (the Hylo mobile app) will be documented 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.3.6] - 2026-03-28
+Fix reset-password routing
+
 ## [6.3.5] - 2026-03-28
 Streamline loading flow
 

--- a/apps/mobile/android/app/build.gradle
+++ b/apps/mobile/android/app/build.gradle
@@ -90,8 +90,8 @@ android {
         applicationId "com.hylo.hyloandroid"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 318
-        versionName "6.3.5"
+        versionCode 319
+        versionName "6.3.6"
     }
     signingConfigs {
         debug {

--- a/apps/mobile/ios/HyloReactNative/Info.plist
+++ b/apps/mobile/ios/HyloReactNative/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.3.5</string>
+	<string>6.3.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -50,7 +50,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>239</string>
+	<string>240</string>
 	<key>FacebookAdvertiserIDCollectionEnabled</key>
 	<false />
 	<key>FacebookAppID</key>

--- a/apps/mobile/ios/HyloReactNativeTests/Info.plist
+++ b/apps/mobile/ios/HyloReactNativeTests/Info.plist
@@ -15,10 +15,10 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.3.5</string>
+	<string>6.3.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>239</string>
+	<string>240</string>
 </dict>
 </plist>

--- a/apps/mobile/ios/OneSignalNotificationServiceExtension/Info.plist
+++ b/apps/mobile/ios/OneSignalNotificationServiceExtension/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.3.5</string>
+	<string>6.3.6</string>
 	<key>CFBundleVersion</key>
-	<string>239</string>
+	<string>240</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile",
-  "version": "6.3.5",
+  "version": "6.3.6",
   "private": true,
   "scripts": {
     "android": "adb reverse tcp:3001 tcp:3001 && adb reverse tcp:3000 tcp:3000 && react-native run-android",

--- a/apps/mobile/src/navigation/linking/getStateFromPath.js
+++ b/apps/mobile/src/navigation/linking/getStateFromPath.js
@@ -89,8 +89,11 @@ export function addParamsToScreenPath (routeMatch) {
     if (!isEmpty(pathMatch.params)) routeParams.push(queryString.stringify(pathMatch.params))
     if (!isEmpty(pathMatcher)) routeParams.push(queryString.stringify({ pathMatcher }))
 
-    // Needed for JoinGroup
-    routeParams.push(`originalLinkingPath=${encodeURIComponent(pathname + search)}`)
+    // Needed for JoinGroup and most other routes. Skip the auth-link handler
+    // route to avoid duplicating very large JWT query strings in nav state.
+    if (pathMatcher !== '/noo/login/(jwt|token)') {
+      routeParams.push(`originalLinkingPath=${encodeURIComponent(pathname + search)}`)
+    }
 
     const routeParamsQueryString = routeParams.join('&')
     const path = `${pathname}?${routeParamsQueryString}`

--- a/apps/mobile/src/screens/LoginByTokenHandler/LoginByTokenHandler.js
+++ b/apps/mobile/src/screens/LoginByTokenHandler/LoginByTokenHandler.js
@@ -9,14 +9,23 @@ import { navigationRef } from 'navigation/linking/helpers'
 import { openURL } from 'hooks/useOpenURL'
 import LoadingScreen from 'screens/LoadingScreen'
 
+function safeDecodeURIComponent (value) {
+  if (typeof value !== 'string') return value
+  try {
+    return decodeURIComponent(value)
+  } catch (err) {
+    return value
+  }
+}
+
 export default function LoginByTokenHandler () {
   const route = useRoute()
   const dispatch = useDispatch()
   const { setReturnToOnAuthPath } = useLinkingStore()
-  const [{ isAuthorized, checkAuth }] = useAuth()
-  const returnToURLFromLink = decodeURIComponent(route?.params?.n)
-  const jwt = decodeURIComponent(route?.params?.token)
-  const loginToken = decodeURIComponent(route?.params?.t || route?.params?.loginToken)
+  const { isAuthorized, checkAuth } = useAuth()
+  const returnToURLFromLink = safeDecodeURIComponent(route?.params?.n)
+  const jwt = safeDecodeURIComponent(route?.params?.token)
+  const loginToken = safeDecodeURIComponent(route?.params?.t || route?.params?.loginToken)
   const userID = route?.params?.u || route?.params?.userId
 
   useFocusEffect(


### PR DESCRIPTION
This is already in review with the stores.

So, the line that was an issue ('const [{ isAuthorized, checkAuth }] = useAuth()' hasn't been changed for 15 months, and neither has useAuth, apparently... and we have absolutely had reset password tests since then. So a bit confused about how this has come to be.

It is also mobile code, so not even related to recent caching changes.

Anywhoo, added some other safer URI decode options as well