### PR TITLE
Fix double-margin gap below comment form on iPhone

### DIFF
--- a/apps/web/src/routes/PostDetail/Comments/CommentForm/CommentForm.js
+++ b/apps/web/src/routes/PostDetail/Comments/CommentForm/CommentForm.js
@@ -95,12 +95,13 @@ function CommentForm ({
       }
 
       // On iOS/iPadOS, the virtual keyboard doesn't shrink the layout viewport,
-      // so the comment form can end up hidden behind the keyboard. Scroll it into
-      // view after a delay to let the keyboard finish animating.
+      // so the comment form can end up hidden behind the keyboard. Scroll it to
+      // the bottom of the visual viewport (just above the keyboard) after a
+      // delay to let the keyboard finish animating.
       setTimeout(() => {
         const formEl = editor.current?.view?.dom?.closest?.('.CommentForm')
         if (formEl) {
-          formEl.scrollIntoView({ behavior: 'smooth', block: 'center' })
+          formEl.scrollIntoView({ behavior: 'smooth', block: 'end' })
         }
       }, 400)
     }

--- a/apps/web/src/routes/PostDetail/Comments/Comments.js
+++ b/apps/web/src/routes/PostDetail/Comments/Comments.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback, useState } from 'react'
+import React, { useEffect, useCallback } from 'react'
 import { array, bool, func, object, number, string } from 'prop-types'
 import { Link } from 'react-router-dom'
 import { useResizeDetector } from 'react-resize-detector'
@@ -42,24 +42,6 @@ const Comments = ({
 
   const { ref, width } = useResizeDetector({ handleHeight: false })
 
-  // On iOS/iPadOS, the virtual keyboard doesn't shrink the layout viewport.
-  // Track the keyboard height via visualViewport and add bottom padding so
-  // the comment form can be scrolled above the keyboard.
-  const [keyboardPadding, setKeyboardPadding] = useState(0)
-
-  useEffect(() => {
-    const vv = window.visualViewport
-    if (!vv) return
-
-    const handleResize = () => {
-      const keyboardHeight = window.innerHeight - vv.height
-      setKeyboardPadding(keyboardHeight > 50 ? keyboardHeight : 0)
-    }
-
-    vv.addEventListener('resize', handleResize)
-    return () => vv.removeEventListener('resize', handleResize)
-  }, [])
-
   const scrollToReplyInput = (elem) => {
     scrollIntoView(elem, { behavior: 'smooth', scrollMode: 'if-needed' })
   }
@@ -69,7 +51,7 @@ const Comments = ({
   }
 
   return (
-    <div className={classes.comments} ref={ref} style={{ paddingBottom: keyboardPadding }}>
+    <div className={classes.comments} ref={ref}>
       <ShowMore
         commentsLength={comments.length}
         total={total}


### PR DESCRIPTION
The visualViewport-based keyboardPadding was being applied on iPhone too, where Safari already keeps the focused input visible — the extra padding became a visible empty gap when scrollIntoView ran with block:'center'. Drop the padding hack and use block:'end' so the form sits just above the keyboard on both iPhone and iPad.