### PR TITLE
1380 mobile link opening follow up

### DIFF
--- a/apps/backend/api/services/OneSignal.js
+++ b/apps/backend/api/services/OneSignal.js
@@ -30,12 +30,17 @@ function createNotificationObject ({ readerId, alert, path, appId, badgeNo }) {
   notification.target_channel = 'push'
 
   if (alert) notification.contents = { en: alert }
-  // Use the hyloapp:// custom scheme so iOS/Android always open the app directly.
-  // HTTPS universal links are NOT triggered by programmatic UIApplication.openURL() calls
-  // (which is how OneSignal opens notification taps) — iOS just opens Safari instead.
-  // Custom schemes bypass this and always route to the registered app.
-  // IN LOCAL DEV: set manually, e.g.: notification.app_url = 'hyloapp://groups/heart-orchard/post/78041'
-  if (path) notification.app_url = 'hyloapp:/' + path
+
+  if (path) {
+    // Send path in additionalData so the mobile click listener can navigate in-app
+    // without iOS calling openURL (which opens Safari before bouncing back to the app).
+    // app_url with hyloapp:// is kept alongside as a fallback for older app versions
+    // that don't yet have the additionalData click handler — they open the app via
+    // the custom scheme as before. Once old versions are no longer in circulation,
+    // app_url can be removed.
+    notification.data = { path }
+    notification.app_url = 'hyloapp:/' + path
+  }
 
   if (badgeNo) {
     notification.ios_badgeType = 'SetTo'

--- a/apps/backend/api/services/OneSignal.js
+++ b/apps/backend/api/services/OneSignal.js
@@ -30,12 +30,12 @@ function createNotificationObject ({ readerId, alert, path, appId, badgeNo }) {
   notification.target_channel = 'push'
 
   if (alert) notification.contents = { en: alert }
-  // Use HTTPS universal links so all app versions handle the URL correctly without custom-scheme
-  // parsing. HTTPS is intercepted by iOS/Android as a universal link when associated domains are
-  // configured, and falls back gracefully to the web app in a browser if the app isn't installed.
-  // IN LOCAL DEV: set path manually, e.g.: notification.app_url = 'https://www.hylo.com/groups/heart-orchard/post/78041'
-  const pushHost = process.env.DOMAIN || 'www.hylo.com'
-  if (path) notification.app_url = `https://${pushHost}${path}`
+  // Use the hyloapp:// custom scheme so iOS/Android always open the app directly.
+  // HTTPS universal links are NOT triggered by programmatic UIApplication.openURL() calls
+  // (which is how OneSignal opens notification taps) — iOS just opens Safari instead.
+  // Custom schemes bypass this and always route to the registered app.
+  // IN LOCAL DEV: set manually, e.g.: notification.app_url = 'hyloapp://groups/heart-orchard/post/78041'
+  if (path) notification.app_url = 'hyloapp:/' + path
 
   if (badgeNo) {
     notification.ios_badgeType = 'SetTo'

--- a/apps/backend/test/unit/models/Notification.test.js
+++ b/apps/backend/test/unit/models/Notification.test.js
@@ -49,6 +49,7 @@ describe('Notification', function () {
       .then(() => group.posts().attach(post))
       .then(() => factories.user({ email: 'readersemail@hylo.com' }).save())
       .then(u => { reader = u })
+      .then(() => group.members().attach(reader))
       .then(() => new Activity({
         post_id: post.id
       }).save())
@@ -155,7 +156,8 @@ describe('Notification', function () {
       })
 
       it('uses a public post URL for comment push when the post is public and the reader is not in the linked group', () => {
-        return post.save({ is_public: true }, { patch: true })
+        return group.members().detach(reader)
+          .then(() => post.save({ is_public: true }, { patch: true }))
           .then(() => preloadNotification(activities.newComment, Notification.MEDIUM.Push))
           .then(notification => notification.send())
           .then(() => PushNotification.where({ user_id: reader.id }).fetchAll())
@@ -164,6 +166,7 @@ describe('Notification', function () {
             const pn = pns.first()
             expect(pn.get('path')).to.match(/\/public\/post\//)
           })
+          .finally(() => group.members().attach(reader))
       })
 
       it('includes commentId as a query param in the comment push path', () => {
@@ -184,8 +187,7 @@ describe('Notification', function () {
           actor_id: actor.id,
           group_id: group.id
         }
-        return group.members().attach(reader)
-          .then(() => preloadNotification(activityWithGroup, Notification.MEDIUM.Push))
+        return preloadNotification(activityWithGroup, Notification.MEDIUM.Push)
           .then(notification => notification.send())
           .then(() => PushNotification.where({ user_id: reader.id }).fetchAll())
           .then(pns => {
@@ -194,7 +196,6 @@ describe('Notification', function () {
             expect(path).to.contain('/groups/my-group/')
             expect(path).to.contain(`commentId=${comment.id}`)
           })
-          .finally(() => group.members().detach(reader))
       })
 
       it('sends a push for a mention in a comment', () => {

--- a/apps/mobile/index.js
+++ b/apps/mobile/index.js
@@ -152,12 +152,15 @@ export default function App () {
       OneSignal.Notifications.addEventListener('foregroundWillDisplay', foregroundWillDisplayHandler)
 
       // Handle notification taps (background and cold-start).
-      // Store the launch URL in the linking store so useOpenInitialURL processes it
-      // after auth is confirmed, giving us one reliable navigation path regardless of
-      // whether the OS Linking event fires first or the click handler fires first.
-      // The URL is the same in both cases, so any double-dispatch is idempotent.
+      // Prefer additionalData.path (a bare path like /groups/slug/post/123?commentId=456)
+      // over launchURL because additionalData bypasses iOS's openURL call — the OS never
+      // gets a chance to open Safari. launchURL is kept as a fallback for any notifications
+      // sent by older backend versions that don't include additionalData.
+      // Either way the URL is stored in the linking store and processed by useOpenInitialURL
+      // after auth is confirmed, giving us one reliable navigation path.
       const notificationClickHandler = (event) => {
-        const url = event.notification.launchURL
+        const path = event.notification.additionalData?.path
+        const url = path ? `https://www.hylo.com${path}` : event.notification.launchURL
         Sentry.addBreadcrumb({ category: 'notification', message: 'Notification tapped', data: { url } })
         console.log('📱 OneSignal notification tapped:', url)
         if (url) {


### PR DESCRIPTION
For #1380  and follow on from #1388

Here's what changed and why each decision was made:

Backend (OneSignal.js): now sends both data: { path } and app_url. Sending both means this backend deploy is safe to ship independently — old app uses app_url (custom scheme, opens app as before), new app uses data.path via the click handler and ignores app_url entirely.

Mobile (index.js): click handler now checks additionalData.path first. If present, it builds a full https://www.hylo.com{path} URL and stores it in the linking store — useOpenURL then handles it via in-app navigation (HTTPS is in prefixes, so it never hits Linking.openURL). If additionalData.path is absent (older backend), it falls back to launchURL as before.

The deployment order for this change: backend can ship first (adding data.path alongside existing app_url doesn't change old-app behavior). Mobile ships whenever App Store approves. There is no window where things break.

When to remove app_url: once you're confident old app versions without the click handler are no longer in active use, remove notification.app_url = 'hyloapp:/' + path from OneSignal.js.