### PR TITLE
Clean up search query

### DIFF
--- a/apps/backend/api/services/FullTextSearch.js
+++ b/apps/backend/api/services/FullTextSearch.js
@@ -53,6 +53,38 @@ const createView = (lang, knex) => {
   )`, knex)
     .then(() => raw(`create index idx_fts_search on ${tableName}
       using gin(${columnName})`, knex))
+    .then(() => raw(`create index idx_search_index_post_id on ${tableName} (post_id) where post_id is not null`, knex))
+    .then(() => raw(`create index idx_search_index_user_id on ${tableName} (user_id) where user_id is not null`, knex))
+    .then(() => raw(`create index idx_search_index_comment_id on ${tableName} (comment_id) where comment_id is not null`, knex))
+}
+
+// Restrict FTS candidates to content the user can see: their groups plus public posts.
+const applyGroupAccessFilter = (qb, groupIds) => {
+  qb.andWhere(function () {
+    if (groupIds.length > 0) {
+      this.whereIn('post_id', function () {
+        this.select('post_id').from('groups_posts').whereIn('group_id', groupIds)
+      })
+        .orWhereIn('user_id', function () {
+          this.select('user_id').from('group_memberships').whereIn('group_id', groupIds)
+        })
+        .orWhereIn('comment_id', function () {
+          this.select('c.id')
+            .from('comments as c')
+            .join('groups_posts as gp', 'gp.post_id', 'c.post_id')
+            .whereIn('gp.group_id', groupIds)
+        })
+    }
+    this.orWhereIn('post_id', function () {
+      this.select('id').from('posts').where({ is_public: true, active: true })
+    })
+      .orWhereIn('comment_id', function () {
+        this.select('c.id')
+          .from('comments as c')
+          .join('posts as p', 'p.id', 'c.post_id')
+          .where({ 'p.is_public': true, 'c.active': true })
+      })
+  })
 }
 
 const search = (opts) => {
@@ -88,6 +120,10 @@ const search = (opts) => {
       comment: 'comment_id is not null'
     }[opts.type] || true))
 
+  if (opts.groupIds) {
+    applyGroupAccessFilter(query, opts.groupIds)
+  }
+
   if (!opts.subquery) {
     query = query.orderBy('rank', 'desc')
   }
@@ -100,20 +136,17 @@ const searchInGroups = (groupIds, opts) => {
   const columns = [`${alias}.post_id`, `${alias}.comment_id`, `${alias}.user_id`, 'rank', 'total']
   return bookshelf.knex
     .select(columns)
-    .from(search(omit(opts, 'limit', 'offset')).as(alias))
-    .leftJoin('group_memberships', 'group_memberships.user_id', `${alias}.user_id`)
+    .from(search({ ...omit(opts, 'limit', 'offset'), groupIds }).as(alias))
     .leftJoin('comments', 'comments.id', `${alias}.comment_id`)
     .leftJoin('posts', function () {
       this.on('posts.id', `${alias}.post_id`)
         .orOn('posts.id', 'comments.post_id')
     })
-    .leftJoin('groups_posts', function () {
-      this.on('groups_posts.post_id', `${alias}.post_id`)
-        .orOn('groups_posts.post_id', 'comments.post_id')
-    })
-    .where(function () {
-      this.whereIn('group_memberships.group_id', groupIds)
-        .orWhereIn('groups_posts.group_id', groupIds)
+    .leftJoin('group_memberships', function () {
+      this.on('group_memberships.user_id', `${alias}.user_id`)
+      if (groupIds.length > 0) {
+        this.andOnIn('group_memberships.group_id', groupIds)
+      }
     })
     .groupBy(columns)
     .orderByRaw('(("rank") * (case when greatest(max(posts.updated_at), max(comments.created_at), max(group_memberships.created_at)) is null then 1 else exp(-extract(epoch from (now() - greatest(max(posts.updated_at), max(comments.created_at), max(group_memberships.created_at)))) / 1209600.0) end)) desc, "rank" desc')

--- a/apps/backend/migrations/20260612160000_add_search_index_id_indexes.js
+++ b/apps/backend/migrations/20260612160000_add_search_index_id_indexes.js
@@ -1,0 +1,23 @@
+exports.up = async function (knex) {
+  await knex.raw(`
+    create index if not exists idx_search_index_post_id
+      on search_index (post_id)
+      where post_id is not null
+  `)
+  await knex.raw(`
+    create index if not exists idx_search_index_user_id
+      on search_index (user_id)
+      where user_id is not null
+  `)
+  await knex.raw(`
+    create index if not exists idx_search_index_comment_id
+      on search_index (comment_id)
+      where comment_id is not null
+  `)
+}
+
+exports.down = async function (knex) {
+  await knex.raw('drop index if exists idx_search_index_post_id')
+  await knex.raw('drop index if exists idx_search_index_user_id')
+  await knex.raw('drop index if exists idx_search_index_comment_id')
+}

--- a/apps/backend/test/unit/services/FullTextSearch.test.js
+++ b/apps/backend/test/unit/services/FullTextSearch.test.js
@@ -24,15 +24,20 @@ describe('FullTextSearch', () => {
           where
             document @@ to_tsquery('english', 'zounds:*')
             and user_id is not null
+            and ("post_id" in (select "post_id" from "groups_posts" where "group_id" in (3, 5))
+              or "user_id" in (select "user_id" from "group_memberships" where "group_id" in (3, 5))
+              or "comment_id" in (select "c"."id" from "comments" as "c"
+                inner join "groups_posts" as "gp" on "gp"."post_id" = "c"."post_id"
+                where "gp"."group_id" in (3, 5))
+              or "post_id" in (select "id" from "posts" where "is_public" = true and "active" = true)
+              or "comment_id" in (select "c"."id" from "comments" as "c"
+                inner join "posts" as "p" on "p"."id" = "c"."post_id"
+                where "p"."is_public" = true and "c"."active" = true))
           order by "rank" desc) as "search"
-        left join "group_memberships" on "group_memberships"."user_id" = "search"."user_id"
         left join "comments" on "comments"."id" = "search"."comment_id"
         left join "posts" on "posts"."id" = "search"."post_id" or "posts"."id" = "comments"."post_id"
-        left join "groups_posts" on
-          "groups_posts"."post_id" = "search"."post_id"
-          or "groups_posts"."post_id" = "comments"."post_id"
-        where ("group_memberships"."group_id" in (3, 5)
-          or "groups_posts"."group_id" in (3, 5))
+        left join "group_memberships" on "group_memberships"."user_id" = "search"."user_id"
+          and "group_memberships"."group_id" in (3, 5)
         group by "search"."post_id", "search"."comment_id", "search"."user_id", "rank", "total"
         order by (("rank") * (case when greatest(max(posts.updated_at), max(comments.created_at), max(group_memberships.created_at)) is null then 1 else exp(-extract(epoch from (now() - greatest(max(posts.updated_at), max(comments.created_at), max(group_memberships.created_at)))) / 1209600.0) end)) desc, "rank" desc
         limit 10

--- a/apps/web/src/routes/Search/Search.js
+++ b/apps/web/src/routes/Search/Search.js
@@ -31,6 +31,8 @@ import { CENTER_COLUMN_ID } from 'util/scrolling'
 
 import classes from './Search.module.scss'
 
+const MIN_SEARCH_TERM_LENGTH = 2
+
 export default function Search (props) {
   const dispatch = useDispatch()
   const location = useLocation()
@@ -42,6 +44,7 @@ export default function Search (props) {
   const groupIds = useMemo(() => group ? [group.id] : null, [group.id])
   const [searchForInput, setSearchForInput] = useState(searchFromQueryString)
   const [filter, setFilter] = useState('all')
+  const searchTermReady = searchForInput.trim().length >= MIN_SEARCH_TERM_LENGTH
   const queryResultProps = { search: searchForInput, type: filter, groupIds }
   const searchResults = useSelector(state => getSearchResults(state, queryResultProps))
   const hasMore = useSelector(state => getHasMoreSearchResults(state, queryResultProps))
@@ -65,17 +68,18 @@ export default function Search (props) {
   )
 
   const fetchSearchResultsAction = useCallback(() => {
+    if (!searchTermReady) return
     return fetchSearchResultsDebounced({ search: searchForInput, filter, groupIds })
-  }, [fetchSearchResultsDebounced, searchForInput, filter, groupIds])
+  }, [fetchSearchResultsDebounced, searchForInput, filter, groupIds, searchTermReady])
 
-  const fetchMoreSearchResults = useCallback(() => hasMore
-    ? fetchSearchResultsDebounced({ search: searchForInput, filter, offset: searchResults.length, groupIds })
-    : () => {},
-  [fetchSearchResultsDebounced, hasMore, searchForInput, filter, searchResults.length, groupIds])
+  const fetchMoreSearchResults = useCallback(() => {
+    if (!searchTermReady || !hasMore) return () => {}
+    return fetchSearchResultsDebounced({ search: searchForInput, filter, offset: searchResults.length, groupIds })
+  }, [fetchSearchResultsDebounced, hasMore, searchForInput, filter, searchResults.length, groupIds, searchTermReady])
 
   useEffect(() => {
     fetchSearchResultsAction()
-  }, [searchForInput, filter, groupIds])
+  }, [fetchSearchResultsAction])
 
   const handleClearGroup = useCallback(() => {
     dispatch(changeQuerystringParam(location, 'groupSlug', null, null, false))

--- a/apps/web/src/routes/Search/Search.test.js
+++ b/apps/web/src/routes/Search/Search.test.js
@@ -1,18 +1,18 @@
 import React from 'react'
 import { render, screen, fireEvent, AllTheProviders } from 'util/testing/reactTestingLibraryExtended'
 import Search from './Search'
-import { FETCH_SEARCH, getSearchResults } from './Search.store'
+import { FETCH_SEARCH } from './Search.store'
 import orm from 'store/models'
 import { ViewHeaderContext } from 'contexts/ViewHeaderContext'
 
 // Mock debounce to execute immediately in tests
 jest.mock('lodash/fp', () => {
-  const original = jest.requireActual('lodash/fp');
+  const original = jest.requireActual('lodash/fp')
   return {
     ...original,
     debounce: (wait, fn) => (...args) => fn(...args)
-  };
-});
+  }
+})
 
 jest.mock('./Search.store', () => {
   // Create a stable reference for the mock results and a cache for memoization
@@ -84,7 +84,7 @@ beforeEach(() => {
   mockGetHasMoreSearchResults.mockClear()
 })
 
-function testProviders(mockResults = []) {
+function testProviders (mockResults = []) {
   const ormSession = orm.mutableSession(orm.getEmptyState())
   ormSession.Me.create({ id: '1' })
 
@@ -180,12 +180,18 @@ describe('Search', () => {
     __setMockResults(mockResults)
 
     // Create a component with props to simulate search terms
-    const props = { searchForInput: "walking" }
+    const props = { searchForInput: 'walking' }
     render(<Search {...props} />, { wrapper: testProviders(mockResults) })
 
     // The component needs to be updated to actually show skills that match
     // This test might need adjustment based on how your component actually works
     // expect(screen.getByText('walking')).toBeInTheDocument()
+  })
+
+  it('does not fetch search results until the term is at least two characters', () => {
+    render(<Search />, { wrapper: testProviders([]) })
+
+    expect(mockFetchSearchResults).not.toHaveBeenCalled()
   })
 
   it('navigates to person profile when clicked', () => {


### PR DESCRIPTION
Closes #1428 


I did some testing on my local db and we can do some on staging but the proof will be in the (prod) pudding

1. Restructure the query (highest impact)
Group access is now applied inside the FTS subquery, with public posts/comments included. Implemented in FullTextSearch.js.

2. Add indexes on search_index ID columns
Partial indexes on post_id, user_id, and comment_id. Migration + createView() update.