### PR TITLE
Improvements to mobile auth

### DIFF
--- a/apps/mobile/src/components/HyloWebView/HyloWebView.js
+++ b/apps/mobile/src/components/HyloWebView/HyloWebView.js
@@ -4,7 +4,7 @@ import Config from 'react-native-config'
 import useRouteParams from 'hooks/useRouteParams'
 import AutoHeightWebView from 'react-native-autoheight-webview'
 import { getSessionCookie, clearSessionCookie, ensureWebViewCookies, sessionCookieFromToken } from 'util/session'
-import { parseWebViewMessage } from '.'
+import { parseWebViewMessage, sendMessageFromWebView } from '.'
 import { useAuth } from '@hylo/contexts/AuthContext'
 import { WebViewMessageTypes } from '@hylo/shared'
 
@@ -47,14 +47,13 @@ const HyloWebView = React.forwardRef(({
   mobileAppVersion,
   onLoadStart: externalOnLoadStart,
   onLoadEnd: externalOnLoadEnd,
+  onSessionRecoveryStart,
+  onSessionRecoveryEnd,
   ...forwardedProps
 }, webViewRef) => {
   const [cookie, setCookie] = useState()
   const [isLoading, setIsLoading] = useState(true)
   const [showSessionRecovery, setShowSessionRecovery] = useState(false)
-  // Bumped to force a full WebView remount (reload) after re-minting the session
-  // cookie in response to a VERIFY_AUTH message from the web app.
-  const [reloadNonce, setReloadNonce] = useState(0)
   const { postId, path: routePath, originalLinkingPath } = useRouteParams()
   const path = pathProp || routePath || originalLinkingPath || ''
   const uri = (source?.uri || `${Config.HYLO_WEB_BASE_URL}${path}`) + (postId ? `?postId=${postId}` : '')
@@ -163,25 +162,27 @@ const HyloWebView = React.forwardRef(({
 
   // Web app reported itself unauthenticated inside the mobile WebView. Native auth
   // (the Keychain token) is the source of truth, so re-mint a fresh server session
-  // from the token, repopulate the WebView cookie jar, and force a reload — rather
-  // than letting the web side log the native app out on a transient cookie desync.
-  // Only when there's genuinely no valid token do we fall through to logout.
+  // from the token, repopulate the WebView cookie jar, and tell the web app to
+  // re-run checkLogin in place — no full page reload.
   const reverifyAuth = useCallback(async () => {
+    onSessionRecoveryStart?.()
     try {
       const fresh = await sessionCookieFromToken()
       if (fresh) {
         await ensureWebViewCookies()
         setCookie(fresh)
-        setReloadNonce(nonce => nonce + 1)
+        sendMessageFromWebView(webViewRef, WebViewMessageTypes.SESSION_READY)
       } else {
+        onSessionRecoveryEnd?.()
         await clearSessionCookie()
         logout()
       }
     } catch (error) {
       console.warn('🔑 HyloWebView re-auth failed:', error)
+      onSessionRecoveryEnd?.()
       logout()
     }
-  }, [logout])
+  }, [logout, onSessionRecoveryEnd, onSessionRecoveryStart, webViewRef])
 
   const handleMessage = message => {
     const parsedMessage = parseWebViewMessage(message)
@@ -189,6 +190,11 @@ const HyloWebView = React.forwardRef(({
 
     if (type === WebViewMessageTypes.VERIFY_AUTH) {
       reverifyAuth()
+      return
+    }
+
+    if (type === WebViewMessageTypes.AUTH_SUCCESS) {
+      onSessionRecoveryEnd?.()
       return
     }
 
@@ -216,9 +222,6 @@ const HyloWebView = React.forwardRef(({
 
   return (
     <AutoHeightWebView
-      // Remounts (and thus reloads) the WebView after a VERIFY_AUTH re-mint so the
-      // web app re-runs its auth check carrying the freshly-minted session cookie.
-      key={reloadNonce}
       // Must run before page JS so window.HyloMobileV2 is visible when the web app's
       // router initialises. Must end with `true` to avoid an Android WebView crash.
       injectedJavaScriptBeforeContentLoaded={injectedJavaScriptBeforeContentLoaded}

--- a/apps/mobile/src/screens/PrimaryWebView/PrimaryWebView.js
+++ b/apps/mobile/src/screens/PrimaryWebView/PrimaryWebView.js
@@ -15,14 +15,14 @@ import useThemeStore from 'store/themeStore'
 
 /**
  * PrimaryWebView - Single full-screen WebView for all authenticated content
- * 
+ *
  * Replaces the previous architecture of multiple specialized WebView screens:
  * - ChatRoomWebView
  * - GroupSettingsWebView
  * - UserSettingsWebView
  * - MapWebView
  * - GroupExploreWebView
- * 
+ *
  * The web app now handles all navigation, UI, and state management.
  * This component handles:
  * 1. Authentication verification (ensures user is logged in)
@@ -43,7 +43,7 @@ export default function PrimaryWebView() {
   // On iOS, use a smaller bottom inset since the UI is simple and doesn't need as much space
   const bottomInset = isIOS ? Math.max(insets.bottom * 0.5, 8) : insets.bottom
   const safeAreaEdges = isIOS ? ['top', 'left', 'right'] : ['top', 'left', 'right', 'bottom']
-  
+
   // Verify user is authenticated before showing WebView.
   // cache-and-network (not network-only) is intentional: with network-only, any
   // re-execution of this query (e.g. caused by a NetInfo null→false→true flicker)
@@ -62,7 +62,8 @@ export default function PrimaryWebView() {
   if (currentUser) hasLoadedUser.current = true
   const [isWebViewLoading, setIsWebViewLoading] = useState(true)
   const [webViewError, setWebViewError] = useState(null)
-  
+  const [sessionRecovering, setSessionRecovering] = useState(false)
+
   // Get the path from the route params
   // This comes from the linking table catch-all: ':path(.*)' -> Main
   const { path, originalLinkingPath } = useRouteParams()
@@ -76,11 +77,12 @@ export default function PrimaryWebView() {
    */
   const messageHandler = useCallback((message) => {
     const { type, data } = message
-    
+
     switch (type) {
       case WebViewMessageTypes.LOGOUT:
         // Web app triggers logout, native handles the actual logout
         console.log('📱 Logout triggered from WebView')
+        setSessionRecovering(false)
         logout()
         break
 
@@ -92,11 +94,11 @@ export default function PrimaryWebView() {
         }
         break
       }
-        
+
       // DEPRECATED: These cases are no longer needed
       // case 'NAVIGATION': Web app handles all navigation now
       // case 'GROUP_DELETED': Web app handles group deletion navigation
-      
+
       default:
         // Log unknown message types in dev for debugging
         if (__DEV__ && type) {
@@ -104,7 +106,7 @@ export default function PrimaryWebView() {
         }
     }
   }, [logout, setTheme])
-  
+
   /**
    * Handle WebView load completion
    */
@@ -138,7 +140,7 @@ export default function PrimaryWebView() {
   // Do NOT fallback to '/' — the proxy serves the marketing landing page there for
   // unauthenticated requests, and the React app never loads to fire the LOGOUT guard.
   const webViewPath = originalLinkingPath || path || '/app'
-  
+
   if (__DEV__) {
     console.log('📱 PrimaryWebView loading path:', {
       path,
@@ -148,16 +150,16 @@ export default function PrimaryWebView() {
       fetchingUser
     })
   }
-  
+
   // Only show NoInternetConnection on the very first load (before the WebView has loaded).
   // After first load, keep the WebView mounted — Android fires isInternetReachable=false
   // events on resume that would otherwise unmount/remount the WebView, causing reload loops.
   if (!hasLoadedUser.current && (!isConnected || !isInternetReachable)) {
     return (
-      <NoInternetConnection 
+      <NoInternetConnection
         onRetry={() => {
           setWebViewError(null)
-        }} 
+        }}
       />
     )
   }
@@ -172,11 +174,11 @@ export default function PrimaryWebView() {
   // Show error screen if WebView failed to load due to network issues
   if (webViewError && (!isConnected || !isInternetReachable)) {
     return (
-      <NoInternetConnection 
+      <NoInternetConnection
         onRetry={() => {
           setWebViewError(null)
           setIsWebViewLoading(true)
-        }} 
+        }}
       />
     )
   }
@@ -186,7 +188,7 @@ export default function PrimaryWebView() {
   //   2. cookie bridge resolution (HyloWebView renders null while getting session cookie)
   //   3. WebView page loading
   // This replaces the previous three separate loading states that caused visible flashes.
-  const showLoadingOverlay = !hasLoadedUser.current || isWebViewLoading
+  const showLoadingOverlay = !hasLoadedUser.current || isWebViewLoading || sessionRecovering
 
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor, paddingBottom: bottomInset }} edges={safeAreaEdges}>
@@ -212,6 +214,8 @@ export default function PrimaryWebView() {
           path={webViewPath}
           mobileAppVersion={hyloAppVersion}
           messageHandler={messageHandler}
+          onSessionRecoveryStart={() => setSessionRecovering(true)}
+          onSessionRecoveryEnd={() => setSessionRecovering(false)}
           onLoadEnd={handleLoadEnd}
           onError={handleError}
           onHttpError={handleHttpError}

--- a/apps/mobile/src/util/session.js
+++ b/apps/mobile/src/util/session.js
@@ -158,25 +158,28 @@ function cookieDomainForUrl (url) {
 
 /**
  * Writes each key-value pair from a parsed cookie object into the WebView's native
- * cookie store for HYLO_WEB_BASE_URL. Called after every setSessionCookie to keep
- * the AsyncStorage cookie and the WebView's jar in sync.
+ * cookie store for both the web host and the API host. Called after every
+ * setSessionCookie to keep the AsyncStorage cookie and the WebView's jar in sync.
  */
 async function syncCookiesToWebView (cookieObj) {
-  const url = Config.HYLO_WEB_BASE_URL
-  if (!url || !cookieObj) return
+  if (!cookieObj) return
 
-  const domain = cookieDomainForUrl(url)
-  const secure = /^https:/i.test(url)
+  const urls = [...new Set([Config.HYLO_WEB_BASE_URL, apiHost].filter(Boolean))]
 
-  await Promise.all(
-    Object.entries(cookieObj).map(([name, value]) =>
-      CookieManager.set(
-        url,
-        { name, value, path: '/', secure, ...(domain ? { domain } : {}) },
-        USE_WEBKIT
+  await Promise.all(urls.map(url => {
+    const domain = cookieDomainForUrl(url)
+    const secure = /^https:/i.test(url)
+
+    return Promise.all(
+      Object.entries(cookieObj).map(([name, value]) =>
+        CookieManager.set(
+          url,
+          { name, value, path: '/', secure, ...(domain ? { domain } : {}) },
+          USE_WEBKIT
+        )
       )
     )
-  )
+  }))
 }
 
 // this is a bag of hacks that probably only works with our current backend.

--- a/apps/web/src/routes/RootRouter/RootRouter.js
+++ b/apps/web/src/routes/RootRouter/RootRouter.js
@@ -105,17 +105,22 @@ export default function RootRouter () {
       const me = action?.payload?.data?.me
       if (debugCheckLogin) {
         const ms = Math.round((typeof performance !== 'undefined' ? performance.now() : Date.now()) - t0)
-        console.info('[Hylo checkLogin]', `${ms}ms`, { hasMe: !!me, pathname })
+        console.info('[Hylo checkLogin]', `${ms}ms`, {
+          hasMe: !!me,
+          pathname: typeof window !== 'undefined' ? window.location.pathname : ''
+        })
       }
     } catch (err) {
       if (debugCheckLogin) {
         const ms = Math.round((typeof performance !== 'undefined' ? performance.now() : Date.now()) - t0)
-        console.info('[Hylo checkLogin]', `${ms}ms`, 'error', err?.message || err, { pathname })
+        console.info('[Hylo checkLogin]', `${ms}ms`, 'error', err?.message || err, {
+          pathname: typeof window !== 'undefined' ? window.location.pathname : ''
+        })
       }
     } finally {
       setLoading(false)
     }
-  }, [dispatch, pathname])
+  }, [dispatch])
 
   useEffect(() => {
     runCheckLogin()
@@ -136,7 +141,7 @@ export default function RootRouter () {
         navigate(path)
       })
     }
-  }, [runCheckLogin])
+  }, [runCheckLogin, navigate])
 
   // Native re-minted the session cookie — re-run checkLogin without a full page reload.
   useEffect(() => {

--- a/apps/web/src/routes/RootRouter/RootRouter.js
+++ b/apps/web/src/routes/RootRouter/RootRouter.js
@@ -1,6 +1,6 @@
 import mixpanel from 'mixpanel-browser'
 import { WebViewMessageTypes } from '@hylo/shared'
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-dom'
 import { connectSocket } from 'client/websockets'
@@ -29,7 +29,23 @@ if (!isTest && config.mixpanel.token) {
 // the session from its token and reload us, retrying a bounded number of times before
 // concluding the native session is genuinely gone.
 const MOBILE_REAUTH_ATTEMPTS_KEY = 'hyloMobileReauthAttempts'
+const MOBILE_RECOVERING_KEY = 'hyloMobileRecovering'
 const MAX_MOBILE_REAUTH_ATTEMPTS = 3
+
+function readMobileRecovering () {
+  try {
+    return window.localStorage?.getItem(MOBILE_RECOVERING_KEY) === '1'
+  } catch (e) {
+    return false
+  }
+}
+
+function writeMobileRecovering (recovering) {
+  try {
+    if (recovering) window.localStorage?.setItem(MOBILE_RECOVERING_KEY, '1')
+    else window.localStorage?.removeItem(MOBILE_RECOVERING_KEY)
+  } catch (e) { /* storage unavailable */ }
+}
 
 function readMobileReauthAttempts () {
   try {
@@ -74,39 +90,35 @@ export default function RootRouter () {
   const dispatch = useDispatch()
   const isAuthorized = useSelector(getAuthorized)
   const [loading, setLoading] = useState(true)
+  const [mobileRecovering, setMobileRecovering] = useState(
+    () => typeof window !== 'undefined' && window.HyloMobileV2 && readMobileRecovering()
+  )
   const navigate = useNavigate()
   const { pathname } = useLocation()
 
   // This should be the only place we check for a session from the API.
-  // Routes will not be available until this check is complete.
-  useEffect(() => {
-    (async function () {
-      setLoading(true)
-      const t0 = typeof performance !== 'undefined' ? performance.now() : Date.now()
-      try {
-        const action = await dispatch(checkLogin())
-        // If the server returns me: null the session/cookie is dead. Clear the
-        // persisted ORM (which may still have a stale Me row) so the app does not
-        // briefly appear authenticated on the next load before checkLogin resolves.
-        const me = action?.payload?.data?.me
-        if (debugCheckLogin) {
-          const ms = Math.round((typeof performance !== 'undefined' ? performance.now() : Date.now()) - t0)
-          console.info('[Hylo checkLogin]', `${ms}ms`, { hasMe: !!me, pathname })
-        }
-        // Explicit `me: null` only — `undefined` has cleared valid sessions when the payload shape was wrong.
-        // XXXX: This breaks logging in production only. Why???
-        // if (me === null) dispatch(logout())
-      } catch (err) {
-        if (debugCheckLogin) {
-          const ms = Math.round((typeof performance !== 'undefined' ? performance.now() : Date.now()) - t0)
-          console.info('[Hylo checkLogin]', `${ms}ms`, 'error', err?.message || err, { pathname })
-        }
-        // XXXX: This breaks logging in production only. Why???
-        // dispatch(logout())
-      } finally {
-        setLoading(false)
+  const runCheckLogin = useCallback(async () => {
+    setLoading(true)
+    const t0 = typeof performance !== 'undefined' ? performance.now() : Date.now()
+    try {
+      const action = await dispatch(checkLogin())
+      const me = action?.payload?.data?.me
+      if (debugCheckLogin) {
+        const ms = Math.round((typeof performance !== 'undefined' ? performance.now() : Date.now()) - t0)
+        console.info('[Hylo checkLogin]', `${ms}ms`, { hasMe: !!me, pathname })
       }
-    }())
+    } catch (err) {
+      if (debugCheckLogin) {
+        const ms = Math.round((typeof performance !== 'undefined' ? performance.now() : Date.now()) - t0)
+        console.info('[Hylo checkLogin]', `${ms}ms`, 'error', err?.message || err, { pathname })
+      }
+    } finally {
+      setLoading(false)
+    }
+  }, [dispatch, pathname])
+
+  useEffect(() => {
+    runCheckLogin()
 
     // For navigation to work from notifactions in the electron app
     if (window.electron && window.electron.onNavigateTo) {
@@ -124,28 +136,49 @@ export default function RootRouter () {
         navigate(path)
       })
     }
-  }, [])
+  }, [runCheckLogin])
+
+  // Native re-minted the session cookie — re-run checkLogin without a full page reload.
+  useEffect(() => {
+    if (!window.HyloMobileV2) return
+
+    const handleNativeMessage = (event) => {
+      try {
+        const payload = JSON.parse(event.data)
+        if (payload?.type !== WebViewMessageTypes.SESSION_READY) return
+        runCheckLogin()
+      } catch (e) { /* non-JSON postMessage */ }
+    }
+
+    window.addEventListener('message', handleNativeMessage, true)
+    return () => window.removeEventListener('message', handleNativeMessage, true)
+  }, [runCheckLogin])
 
   // Mobile WebView re-auth handshake. Once checkLogin has resolved:
-  // - authorized → reset the attempt counter (healthy session).
-  // - unauthorized inside the v2 WebView → ask native to re-mint the session from
-  //   its token and reload us (VERIFY_AUTH). After MAX attempts without success the
-  //   native session really is gone, so send LOGOUT to let native show its login UI.
-  // Non-mobile web is unaffected (window.HyloMobileV2 is undefined → falls through).
+  // - authorized → reset counters and open the socket.
+  // - unauthorized → ask native to re-mint the session (VERIFY_AUTH). Native syncs
+  //   cookies and posts SESSION_READY so we can retry in place. After MAX failures,
+  //   send LOGOUT so native shows its login UI.
   useEffect(() => {
     if (loading) return
     if (!window.HyloMobileV2) return
 
     if (isAuthorized) {
       writeMobileReauthAttempts(0)
+      writeMobileRecovering(false)
+      setMobileRecovering(false)
       sendMessageToWebView(WebViewMessageTypes.AUTH_SUCCESS)
       connectSocket()
       return
     }
 
+    writeMobileRecovering(true)
+    setMobileRecovering(true)
     const attempts = readMobileReauthAttempts()
     if (attempts >= MAX_MOBILE_REAUTH_ATTEMPTS) {
       writeMobileReauthAttempts(0)
+      writeMobileRecovering(false)
+      setMobileRecovering(false)
       sendMessageToWebView(WebViewMessageTypes.LOGOUT)
       return
     }
@@ -153,8 +186,8 @@ export default function RootRouter () {
     sendMessageToWebView(WebViewMessageTypes.VERIFY_AUTH)
   }, [loading, isAuthorized])
 
-  if (loading) {
-    if (isNeutralRootSessionLoadingPath(pathname)) {
+  if (loading || mobileRecovering) {
+    if (window.HyloMobileV2 || isNeutralRootSessionLoadingPath(pathname)) {
       return <Loading type='fullscreen' />
     }
     return <BootstrapShell />
@@ -170,10 +203,7 @@ export default function RootRouter () {
     )
   }
   // In the v2 mobile WebView, native owns auth (token-based) and is the source of truth.
-  // A passive auth-check miss here (e.g. a transient WebView cookie desync on resume) must
-  // NOT log the native app out. The effect above drives the recovery handshake (VERIFY_AUTH
-  // → native re-mints the session and reloads); we just render a neutral loading state while
-  // that round-trips, instead of the web login page.
+  // Stay on a single fullscreen spinner during cookie recovery instead of flashing the page.
   if (!isAuthorized && window.HyloMobileV2) {
     return <Loading type='fullscreen' />
   }

--- a/apps/web/src/routes/RootRouter/RootRouter.js
+++ b/apps/web/src/routes/RootRouter/RootRouter.js
@@ -141,7 +141,11 @@ export default function RootRouter () {
         navigate(path)
       })
     }
-  }, [runCheckLogin, navigate])
+    // Mount-only: `navigate` is intentionally omitted. In the non-data router this app
+    // uses, `useNavigate()` returns a new identity on every route change, so including it
+    // here would re-run `checkLogin` on every in-app navigation — flashing the root spinner
+    // and remounting AuthLayoutRouter (its bootstrap skeleton) on each transition.
+  }, [runCheckLogin])
 
   // Native re-minted the session cookie — re-run checkLogin without a full page reload.
   useEffect(() => {

--- a/packages/shared/src/constants.js
+++ b/packages/shared/src/constants.js
@@ -38,6 +38,9 @@ export const WebViewMessageTypes = {
   VERIFY_AUTH: 'VERIFY_AUTH',
   // Web app confirmed checkLogin succeeded inside the v2 mobile WebView.
   AUTH_SUCCESS: 'AUTH_SUCCESS',
+  // Native re-minted the session cookie and synced the WebView jar — re-run checkLogin
+  // in place instead of reloading the whole page.
+  SESSION_READY: 'SESSION_READY',
   NAVIGATION: 'NAVIGATION',
   THEME_CHANGE: 'THEME_CHANGE',
   EDITOR: {


### PR DESCRIPTION
Improve mobile WebView auth recovery UX with in-place retry and steady spinner. When the web app detected a cookie desync it remounted the entire WebView on each VERIFY_AUTH, causing visible reload flashes before logout.

Mobile:
- Re-mint the session on VERIFY_AUTH and post SESSION_READY so the web app can re-run checkLogin in place instead of reloading the document
- Sync session cookies to both HYLO_WEB_BASE_URL and API_HOST so GraphQL requests see the same session as native
- Keep PrimaryWebView’s spinner overlay up during recovery (AUTH_SUCCESS/LOGOUT clears it)

Web:
- Re-run checkLogin in place on SESSION_READY from native instead of requiring a document reload (pairs with an upcoming mobile release)
- Persist recovery state in localStorage so the fullscreen spinner survives WebView reloads on older app builds
- Always show fullscreen loading in HyloMobileV2 during initial load and cookie recovery (fixes blank /app on first open)
- Extract runCheckLogin for reuse on mount and SESSION_READY
- Add WebViewMessageTypes.SESSION_READY to shared constants