### PR TITLE
Fix isDateInTheFuture always returning true for string dates

### DIFF
--- a/packages/shared/src/TextHelpers.js
+++ b/packages/shared/src/TextHelpers.js
@@ -161,7 +161,9 @@ export function humanDate (date, short) {
 }
 
 export function isDateInTheFuture (date) {
-  return typeof date === 'string' ? DateTime.fromISO(date) : DateTime.fromJSDate(date) > DateTime.now()
+  // NOTE: the parens matter, without them the ternary swallows the comparison and
+  // a string date returns a (always truthy) DateTime instead of a boolean
+  return (typeof date === 'string' ? DateTime.fromISO(date) : DateTime.fromJSDate(date)) > DateTime.now()
 }
 
 /**

--- a/packages/shared/src/TextHelpers.test.js
+++ b/packages/shared/src/TextHelpers.test.js
@@ -43,3 +43,33 @@ describe('sanitizeURL', () => {
     expect(TextHelpers.sanitizeURL('www.hylo.com')).toBe('https://www.hylo.com')
   })
 })
+
+describe('isDateInTheFuture', () => {
+  const past = DateTime.now().minus({ years: 1 })
+  const future = DateTime.now().plus({ years: 1 })
+
+  it('returns false for a past ISO string', () => {
+    expect(TextHelpers.isDateInTheFuture(past.toISO())).toBe(false)
+  })
+
+  it('returns true for a future ISO string', () => {
+    expect(TextHelpers.isDateInTheFuture(future.toISO())).toBe(true)
+  })
+
+  it('returns false for a past Date', () => {
+    expect(TextHelpers.isDateInTheFuture(past.toJSDate())).toBe(false)
+  })
+
+  it('returns true for a future Date', () => {
+    expect(TextHelpers.isDateInTheFuture(future.toJSDate())).toBe(true)
+  })
+
+  it('returns false for an unparseable string', () => {
+    expect(TextHelpers.isDateInTheFuture('not a date')).toBe(false)
+  })
+
+  it('returns false when there is no date', () => {
+    expect(TextHelpers.isDateInTheFuture(null)).toBe(false)
+    expect(TextHelpers.isDateInTheFuture(undefined)).toBe(false)
+  })
+})


### PR DESCRIPTION
This PR proposes fixing `TextHelpers.isDateInTheFuture`, which always reports "in the future" when it is given a date as a string, so post cards keep showing `Starts:` / `Ends:` for events that already started or ended. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/199. You can sign in with your GitHub ID to claim ownership of the project.

## The defect

`isDateInTheFuture` in `packages/shared/src/TextHelpers.js` is a ternary whose comparison only applies to one branch, because `?:` binds looser than `>`:

```js
return typeof date === 'string' ? DateTime.fromISO(date) : DateTime.fromJSDate(date) > DateTime.now()
```

The string branch returns a Luxon `DateTime` — an object, so always truthy — instead of a boolean. Only the `Date` branch actually compares against now.

That matters because `apps/web/src/components/PostCard/PostHeader/PostHeader.js` calls it three times on `startTime` / `endTime` straight off the GraphQL response, where they are ISO strings (the web app does not run posts through `PostPresenter`, which is what converts them to `Date` for mobile). Every one of those calls therefore takes the "future" path, and the `Started:` / `Ended:` labels below them are unreachable — including the translations you already ship for them (`es.json` has `Empezó desde:` and `Terminado:`). It also lines up with the symptom in #459, where a past event still presents as upcoming.

## Reproducing it on `dev` at HEAD

On current `dev` (`386ae32`), drop this into `packages/shared/src/repro.test.js` and run `yarn jest src/repro.test.js` from `packages/shared`. It passes a past date as a string, and the same date as a `Date` for a control:

```js
import * as TextHelpers from './TextHelpers'

it('repro', () => {
  const past = '2020-01-01T00:00:00.000Z'
  console.log('typeof:', typeof TextHelpers.isDateInTheFuture(past))
  console.log('truthy:', Boolean(TextHelpers.isDateInTheFuture(past)))
  console.log('Date control:', TextHelpers.isDateInTheFuture(new Date(past)))

  // the label logic from PostHeader.js, over an event that ended in March 2025
  const startTime = '2025-03-01T18:00:00.000Z'
  const endTime = '2025-03-01T20:00:00.000Z'
  const startString = TextHelpers.isDateInTheFuture(startTime)
    ? 'Starts: ...'
    : TextHelpers.isDateInTheFuture(endTime) ? 'Started: ...' : false
  const endString = TextHelpers.isDateInTheFuture(endTime) ? 'Ends: ...' : 'Ended: ...'
  console.log('rendered timeWindow ->', startString ? `${startString} / ${endString}` : endString)
})
```

```
typeof: object
truthy: true
Date control: false
rendered timeWindow -> Starts: ... / Ends: ...
```

The `Date` control returns `false` correctly; the string returns a truthy `DateTime`, and an event that ended over a year ago still renders as `Starts: ... / Ends: ...`. With the fix applied, the same snippet prints `Date control: false`, `truthy: false`, and `rendered timeWindow -> Ended: ...`.

## The change

One line: parenthesize the ternary so the `> DateTime.now()` comparison applies to both branches, which is the same semantics your `DateTimeHelpers.isDateInTheFuture` already implements. `Date` inputs are unaffected; the only behavior that changes is that string dates (and unparseable strings) now return a real boolean. All three call sites use the result in boolean position, so nothing downstream needs to change. After the fix the same label logic renders `Ended: ...`.

## Verification

Added six cases to `packages/shared/src/TextHelpers.test.js` covering past/future ISO strings, past/future `Date` objects as controls, an unparseable string, and `null`/`undefined`. Three of them fail against the unmodified source and pass with the change:

```
$ yarn jest src/TextHelpers.test.js        # unmodified TextHelpers.js, new tests
  ✕ returns false for a past ISO string
  ✕ returns true for a future ISO string
  ✓ returns false for a past Date
  ✓ returns true for a future Date
  ✕ returns false for an unparseable string
  ✓ returns false when there is no date
Tests: 3 failed, 12 passed, 15 total

$ yarn jest src/TextHelpers.test.js        # with the fix
Tests: 15 passed, 15 total
```

The whole `packages/shared` suite was run before and after, and the failure set is identical — the four `formatDatePair` snapshot failures in `DateTimeHelpers.test.ts` are pre-existing on `dev` (recorded snapshots say `6:41 PM`, current ICU renders `6:41 pm`) and are untouched here. Totals went from `4 failed, 52 passed` to `4 failed, 58 passed`. `standard` is clean on both changed files when run from `packages/shared`, and `yarn shared:build` still succeeds.

One thing worth flagging separately, since it is not part of this change: `apps/web`'s Jest run does not currently get as far as executing `PostHeader.test.js` on `dev` — it stops at `SyntaxError: Cannot use import statement outside a module` from `src/components/ui/tooltip.tsx`, which the transform does not pick up. That is why the regression coverage here lives in `packages/shared`, where the function does.

## How this was managed

This work was tracked on a live agile board imported from your issues and pull requests — 1368 stories and 30 labels — with this fix carried by its own story: [TextHelpers.isDateInTheFuture always reports true for ISO string dates](https://eastagiletracker.com/projects/199/stories/63583), on the board at https://eastagiletracker.com/projects/199.

![board](https://raw.githubusercontent.com/eastagiletracker/hylo/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
