### PR TITLE
Add Cloud Agent dev environment setup for Hylo monorepo

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,15 @@
+{
+  "name": "Hylo Monorepo",
+  "install": "bash .cursor/install.sh",
+  "start": "bash .cursor/start.sh",
+  "terminals": [
+    {
+      "name": "backend",
+      "command": "bash -lc 'cd apps/backend && yarn dev'"
+    },
+    {
+      "name": "web",
+      "command": "bash -lc 'cd apps/web && yarn dev'"
+    }
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Cloud Agent environment install for the Hylo monorepo.
+# Idempotent: safe to re-run. Performs durable, source-derived setup so the
+# resulting state can be captured in an environment snapshot/build:
+#   - Node 24 (via nvm) + Yarn 4.9.2 (via corepack)
+#   - PostgreSQL + PostGIS and Redis (system packages)
+#   - JS dependencies + shared package builds
+#   - Backend/web .env files with safe local-dev placeholders
+#   - hylo / hylo_test databases loaded from migrations/schema.sql
+#   - Dummy seed data (test@hylo.com / hylo)
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+NODE_VERSION="24"
+PG_VERSION="16"
+
+log() { echo "[install] $*"; }
+
+# ---------------------------------------------------------------------------
+# 1. Node 24 + Yarn 4.9.2
+# ---------------------------------------------------------------------------
+export NVM_DIR="$HOME/.nvm"
+if [ ! -s "$NVM_DIR/nvm.sh" ]; then
+  log "Installing nvm"
+  curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+fi
+# shellcheck disable=SC1091
+. "$NVM_DIR/nvm.sh"
+
+log "Installing Node $NODE_VERSION"
+nvm install "$NODE_VERSION" >/dev/null
+nvm alias default "$NODE_VERSION" >/dev/null
+nvm use "$NODE_VERSION" >/dev/null
+
+NODE_BIN_DIR="$(dirname "$(nvm which "$NODE_VERSION")")"
+# Ensure login shells (used by the `terminals`) prefer Node 24 over any
+# pre-existing node on PATH.
+PATH_LINE="export PATH=\"$NODE_BIN_DIR:\$PATH\""
+for rc in "$HOME/.bashrc" "$HOME/.profile"; do
+  touch "$rc"
+  grep -qF "$NODE_BIN_DIR" "$rc" || echo "$PATH_LINE" >> "$rc"
+done
+export PATH="$NODE_BIN_DIR:$PATH"
+
+log "Enabling Yarn 4.9.2 via corepack"
+corepack enable
+corepack prepare yarn@4.9.2 --activate
+
+log "node=$(node --version) yarn=$(yarn --version)"
+
+# ---------------------------------------------------------------------------
+# 2. System services: PostgreSQL + PostGIS and Redis
+# ---------------------------------------------------------------------------
+if ! command -v psql >/dev/null 2>&1 || ! command -v redis-server >/dev/null 2>&1; then
+  log "Installing PostgreSQL + PostGIS and Redis"
+  sudo apt-get update -y
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    postgresql "postgresql-contrib" postgis "postgresql-${PG_VERSION}-postgis-3" \
+    redis-server build-essential python3 pkg-config
+fi
+
+log "Starting Redis"
+sudo service redis-server start || true
+
+log "Starting PostgreSQL"
+sudo pg_ctlcluster "$PG_VERSION" main start 2>/dev/null || sudo service postgresql start || true
+# Wait for Postgres to accept connections
+for _ in $(seq 1 30); do
+  if sudo -u postgres pg_isready -q 2>/dev/null; then break; fi
+  sleep 1
+done
+
+# Create a login role matching the current user with DB privileges, and enable
+# trust auth for local TCP connections (local development only).
+DB_USER="$(whoami)"
+sudo -u postgres psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='$DB_USER'" | grep -q 1 || \
+  sudo -u postgres psql -c "CREATE ROLE \"$DB_USER\" WITH LOGIN SUPERUSER CREATEDB CREATEROLE;"
+
+HBA_FILE="$(sudo -u postgres psql -tA -c 'SHOW hba_file;')"
+sudo sed -i -E "s#^host\s+all\s+all\s+127\.0\.0\.1/32\s+\S+#host all all 127.0.0.1/32 trust#" "$HBA_FILE"
+sudo sed -i -E "s#^host\s+all\s+all\s+::1/128\s+\S+#host all all ::1/128 trust#" "$HBA_FILE"
+sudo pg_ctlcluster "$PG_VERSION" main reload 2>/dev/null || sudo service postgresql reload || true
+
+# ---------------------------------------------------------------------------
+# 3. JS dependencies + shared packages
+# ---------------------------------------------------------------------------
+log "Installing JS dependencies (yarn install)"
+yarn install
+
+log "Building shared packages"
+yarn build-packages
+
+# ---------------------------------------------------------------------------
+# 4. Environment files (safe local-dev placeholders)
+# ---------------------------------------------------------------------------
+BACKEND_ENV="apps/backend/.env"
+WEB_ENV="apps/web/.env"
+
+if [ ! -f "$BACKEND_ENV" ]; then
+  log "Creating $BACKEND_ENV"
+  cp apps/backend/.env.example "$BACKEND_ENV"
+  # Fake Stripe keys so the server boots (Stripe features stay disabled).
+  sed -i 's|^STRIPE_SECRET_KEY=.*|STRIPE_SECRET_KEY=sk_test_fake_key_for_local_development|' "$BACKEND_ENV"
+  sed -i 's|^STRIPE_PUBLISHABLE_KEY=.*|STRIPE_PUBLISHABLE_KEY=pk_test_fake_key_for_local_development|' "$BACKEND_ENV"
+  # The oidc-provider requires a PKCS#1 ("BEGIN RSA PRIVATE KEY") key; modern
+  # OpenSSL emits PKCS#8 by default, so generate the traditional format.
+  OIDC_KEY="$(openssl genrsa -traditional 2048 2>/dev/null | base64 -w0)"
+  node -e 'const fs=require("fs");const f=process.argv[1];let s=fs.readFileSync(f,"utf8");s=s.replace(/^OIDC_KEYS=.*$/m,"OIDC_KEYS="+process.argv[2]);fs.writeFileSync(f,s)' "$BACKEND_ENV" "$OIDC_KEY"
+fi
+
+if [ ! -f "$WEB_ENV" ]; then
+  log "Creating $WEB_ENV"
+  cp apps/web/.env.example "$WEB_ENV"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Databases: schema + dummy seed
+# ---------------------------------------------------------------------------
+create_db_with_schema() {
+  local db="$1"
+  if ! psql -h localhost -U "$DB_USER" -lqt | cut -d'|' -f1 | grep -qw "$db"; then
+    log "Creating database $db and loading schema"
+    createdb -h localhost -U "$DB_USER" "$db"
+    psql -h localhost -U "$DB_USER" -d "$db" -q -f apps/backend/migrations/schema.sql
+  fi
+}
+
+create_db_with_schema hylo
+create_db_with_schema hylo_test
+
+# Seed dummy data only if the DB looks empty. The faker-based seed can hit
+# random unique-name collisions, so retry a few times (as the README notes).
+USER_COUNT="$(psql -h localhost -U "$DB_USER" -d hylo -tA -c 'SELECT count(*) FROM users' 2>/dev/null || echo 0)"
+if [ "${USER_COUNT:-0}" -lt 2 ]; then
+  log "Seeding dummy data"
+  pushd apps/backend >/dev/null
+  seeded=0
+  for _ in $(seq 1 8); do
+    if echo "yes" | NODE_ENV=dummy yarn knex seed:run 2>&1 | grep -q "Error during seeding"; then
+      log "Seed hit a random collision; retrying"
+      continue
+    fi
+    seeded=1
+    break
+  done
+  popd >/dev/null
+  [ "$seeded" = "1" ] && log "Seed complete" || log "WARNING: seed did not complete cleanly"
+fi
+
+log "Install complete."

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Per-boot startup for the Hylo monorepo Cloud Agent environment.
+# Databases and dependencies are prepared in install.sh (and captured in the
+# environment snapshot); here we only (re)start the ephemeral service
+# processes that do not survive into a new pod. The dev servers themselves run
+# as `terminals` so their logs are visible and restartable.
+set -euo pipefail
+
+PG_VERSION="16"
+
+echo "[start] Starting Redis"
+sudo service redis-server start || true
+
+echo "[start] Starting PostgreSQL"
+sudo pg_ctlcluster "$PG_VERSION" main start 2>/dev/null || sudo service postgresql start || true
+
+for _ in $(seq 1 30); do
+  if sudo -u postgres pg_isready -q 2>/dev/null; then
+    echo "[start] PostgreSQL is ready"
+    break
+  fi
+  sleep 1
+done

--- a/apps/backend/seeds/dummy/dummy.js
+++ b/apps/backend/seeds/dummy/dummy.js
@@ -233,11 +233,6 @@ function randomIndex (length) {
   return Math.floor(Math.random() * length)
 }
 
-function moderatorOrMember () {
-  // Role 1 is moderator
-  return Math.random() > 0.9 ? 1 : 0
-}
-
 function addUsersToGroups (knex) {
   console.info('  --> group_memberships')
   return knex('users').select('id')
@@ -387,7 +382,6 @@ function fakeMembership (user_id, knex) {
         active: true,
         group_id: group.id,
         created_at: knex.fn.now(),
-        role: moderatorOrMember(),
         settings: '{ "send_email": true, "send_push_notifications": true }',
         user_id
       }))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up a reproducible development environment for the Hylo monorepo so Cloud Agents (and local devs) can boot into a fully working stack, and fixes a bug that broke the documented database seeding flow.

### What's included

- **`.cursor/environment.json`** + **`.cursor/install.sh`** / **`.cursor/start.sh`** — an idempotent, repo-managed Cloud Agent environment that provisions the full local dev stack:
  - Node 24 (via nvm) + Yarn 4.9.2 (via corepack)
  - PostgreSQL + PostGIS and Redis (with a local-dev trust-auth role)
  - JS dependencies (`yarn install`) and shared package builds (`yarn build-packages`)
  - `apps/backend/.env` and `apps/web/.env` from the examples, with safe local-dev placeholders (fake Stripe test keys; a freshly generated PKCS#1 `OIDC_KEYS`)
  - `hylo` / `hylo_test` databases loaded from `apps/backend/migrations/schema.sql`
  - Dummy seed data (`test@hylo.com` / `hylo`)
  - Backend and web dev servers run as `terminals`

- **Dummy seed fix** — the dummy seed inserted a `role` column into `group_memberships` that no longer exists in the current schema (roles are now modeled via `group_memberships_group_roles` / `groups_roles`). This broke the README's "fresh instance with generic data" flow. Removed the stale field and the now-unused `moderatorOrMember` helper.

### Environment quirks worth noting

- The example `OIDC_KEYS` in `.env.example` is a PKCS#8 key (`BEGIN PRIVATE KEY`), but `oidc-provider` / `rsa-pem-to-jwk` require PKCS#1 (`BEGIN RSA PRIVATE KEY`). Modern OpenSSL emits PKCS#8 even for `genrsa`, so the install script uses `openssl genrsa -traditional`.
- `STRIPE_SECRET_KEY` is required at boot (`StripeService` throws otherwise); the install script sets a fake `sk_test_...` key so the server lifts with Stripe features disabled (matching the test setup).

## Test plan

- **Live environment:** both dev servers run — backend (Sails) lifts on `:3001`, web (Vite) serves on `:3000`.
- Backend GraphQL responds: `POST /noo/graphql {"query":"{ __typename }"}` → `{"data":{"__typename":"Query"}}`.
- Login works end-to-end with the seeded account (`test@hylo.com` / `hylo`); the authenticated feed renders with seeded groups/posts.
- `.cursor/install.sh` re-runs cleanly (idempotent), exit 0.
- **Fresh build validation:** a Cloud Agent draft environment build of this branch **SUCCEEDED** — a clean pod ran `.cursor/install.sh` end-to-end (Node 24/Yarn, Postgres+PostGIS/Redis, deps, package builds, `.env` files, DB schema, `Seed complete`) with exit code 0 in ~100s.

### Login demo

[hylo_login_demo.mp4](https://cursor.com/agents/bc-0295fd2f-3358-40c6-9aef-63e0caa2c27f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhylo_login_demo.mp4)

[Authenticated Hylo feed with seeded content](https://cursor.com/agents/bc-0295fd2f-3358-40c6-9aef-63e0caa2c27f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhylo_authenticated_feed.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0295fd2f-3358-40c6-9aef-63e0caa2c27f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0295fd2f-3358-40c6-9aef-63e0caa2c27f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

