### PR TITLE
Fix locale-dependent case ordering in i18n key sort

### DIFF
--- a/scripts/i18n/lib.js
+++ b/scripts/i18n/lib.js
@@ -26,8 +26,13 @@ function sortLocaleDeep (value) {
     if (lowerA !== lowerB) {
       return lowerA.localeCompare(lowerB)
     }
-    // If case-insensitive equal, uppercase comes before lowercase
-    return b.localeCompare(a, undefined, { sensitivity: 'case' })
+    // If case-insensitive equal, uppercase comes before lowercase.
+    // Use code-unit comparison (uppercase code points are smaller) so the
+    // order is deterministic and doesn't depend on the runtime locale:
+    // localeCompare's case ordering varies between locales (e.g. 'en' vs 'da').
+    if (a < b) return -1
+    if (a > b) return 1
+    return 0
   })) {
     sorted[key] = sortLocaleDeep(value[key])
   }


### PR DESCRIPTION
Fixes #1266

## The bug

`sortLocaleDeep` in `scripts/i18n/lib.js` documents its tie-break as *"If case-insensitive equal, uppercase comes before lowercase"*, but the implementation used:

```js
return b.localeCompare(a, undefined, { sensitivity: 'case' })
```

The reporter saw lowercase sorted before uppercase — contradicting both the comment and `lib.test.js`, which asserts `['A', 'a', 'B', 'b']`.

## Root cause

`localeCompare`'s ordering of case variants is **locale-dependent**. With the default runtime locale it happens to put uppercase first (so the test passed), but with other locales it does not — for example with Danish collation, `'a'.localeCompare('A', 'da', { sensitivity: 'case' })` returns `-1`, flipping the order. So the function contradicted its documented intent on machines with certain locales.

## The fix

Replace the tie-break with a locale-independent code-unit comparison (`a < b` / `a > b`), where uppercase code points are always smaller, so keys that are case-insensitively equal deterministically sort uppercase first on every machine — matching the comment and the existing test.

## Verification

- `npx jest scripts/i18n/lib.test.js` — 5/5 pass (including the uppercase-first assertion)
- Demonstrated the locale variance: `'a'` vs `'A'` with `sensitivity: 'case'` differs between `en`/`sv` (`-1`) and `da` (`+1`)