### PR TITLE
Add Remove Member action to profile page's three-dot menu

### DIFF
--- a/apps/web/src/routes/MemberProfile/MemberProfile.js
+++ b/apps/web/src/routes/MemberProfile/MemberProfile.js
@@ -1,5 +1,5 @@
 import { filter, isFunction } from 'lodash'
-import { Pencil, X } from 'lucide-react'
+import { Pencil, Trash2, X } from 'lucide-react'
 import React, { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import CopyToClipboard from 'react-copy-to-clipboard'
@@ -15,6 +15,7 @@ import Button from 'components/Button'
 import BadgeEmoji from 'components/BadgeEmoji'
 import ClickCatcher from 'components/ClickCatcher'
 import Dropdown from 'components/Dropdown'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from 'components/ui/dialog'
 import HyloHTML from 'components/HyloHTML'
 import Icon from 'components/Icon'
 import NotFound from 'components/NotFound'
@@ -33,7 +34,10 @@ import { useViewHeader } from 'contexts/ViewHeaderContext'
 import { useEffectiveGroupSlug } from 'contexts/SpaceGroupContext'
 import useViewPostDetails from 'hooks/useViewPostDetails'
 import blockUser from 'store/actions/blockUser'
+import { removeMember } from 'routes/Members/Members.store'
+import { RESP_REMOVE_MEMBERS } from 'store/constants'
 import { twitterUrl, AXOLOTL_ID } from 'store/models/Person'
+import { getResponsibilityTitlesForGroup } from 'store/selectors/getResponsibilitiesForGroup'
 import getRolesForGroup from 'store/selectors/getRolesForGroup'
 import isPendingFor from 'store/selectors/isPendingFor'
 import getPreviousLocation from 'store/selectors/getPreviousLocation'
@@ -87,9 +91,14 @@ const MemberProfile = ({ currentTab = 'Overview', blockConfirmMessage, isSingleC
   const roles = useSelector(state => getRolesForGroup(state, { person, groupId: group?.id }))
   const currentUser = useSelector(getMe)
   const previousLocation = useSelector(getPreviousLocation) || { pathname: '/' }
+  // Spaces inherit roles/responsibilities from the parent group
+  const roleGroupId = group?.parentId || group?.id
+  const currentUserResponsibilities = useSelector(state =>
+    getResponsibilityTitlesForGroup(state, { person: currentUser, groupId: roleGroupId }))
 
   const fetchPersonAction = (id) => dispatch(fetchPerson(id))
   const blockUserAction = (id) => dispatch(blockUser(id))
+  const removeMemberAction = (id) => dispatch(removeMember(id, group.id, groupSlug))
   const push = (url) => navigate(url)
   const goToPreviousLocation = () => navigate(previousLocation)
 
@@ -109,6 +118,8 @@ const MemberProfile = ({ currentTab = 'Overview', blockConfirmMessage, isSingleC
   const [showFullBio, setShowFullBio] = useState(false)
   const [isBioClamped, setIsBioClamped] = useState(false)
   const bioRef = useRef(null)
+
+  const [confirmingRemove, setConfirmingRemove] = useState(false)
 
   const { setHeaderDetails } = useViewHeader()
   useEffect(() => {
@@ -178,6 +189,11 @@ const MemberProfile = ({ currentTab = 'Overview', blockConfirmMessage, isSingleC
     }
   }
 
+  const confirmRemoveMember = () => {
+    setConfirmingRemove(false)
+    removeMemberAction(personId).then(goToPreviousLocation)
+  }
+
   const toggleShowAllGroups = () => {
     setShowAllGroups(!showAllGroups)
   }
@@ -201,6 +217,7 @@ const MemberProfile = ({ currentTab = 'Overview', blockConfirmMessage, isSingleC
   const locationWithoutUsa = person.location && person.location.replace(', United States', '')
   const isCurrentUser = currentUser && currentUser.id === personId
   const isAxolotl = AXOLOTL_ID === personId
+  const canRemove = Boolean(group?.id) && currentUserResponsibilities.includes(RESP_REMOVE_MEMBERS)
   const contentDropDownItems = [
     { id: 'Overview', label: t('Overview'), title: t('{{name}}\'s recent activity', { name: person.name }), component: RecentActivity },
     { id: 'Posts', label: t('Posts'), title: t('{{name}}\'s posts', { name: person.name }), component: MemberPosts },
@@ -220,7 +237,8 @@ const MemberProfile = ({ currentTab = 'Overview', blockConfirmMessage, isSingleC
   ]
   const actionDropdownItems = [
     { icon: <Pencil className='w-4 h-4 text-foreground' />, label: t('Edit Profile'), onClick: () => push(currentUserSettingsUrl()), hide: !isCurrentUser },
-    { icon: <X className='w-4 h-4 text-foreground' />, label: t('Block this Member'), onClick: () => handleBlockUser(personId), hide: isCurrentUser || isAxolotl }
+    { icon: <X className='w-4 h-4 text-foreground' />, label: t('Block this Member'), onClick: () => handleBlockUser(personId), hide: isCurrentUser || isAxolotl },
+    { icon: <Trash2 className='w-4 h-4 text-destructive' />, label: t('Remove member from group'), onClick: () => setConfirmingRemove(true), hide: isCurrentUser || isAxolotl || !canRemove }
   ]
   const {
     title: currentContentTitle,
@@ -259,6 +277,38 @@ const MemberProfile = ({ currentTab = 'Overview', blockConfirmMessage, isSingleC
             <ActionButtons items={actionButtonsItems} />
             <ActionDropdown items={actionDropdownItems} />
           </div>
+          {canRemove && (
+            <Dialog open={confirmingRemove} onOpenChange={setConfirmingRemove}>
+              <DialogContent className='max-w-md'>
+                <DialogHeader>
+                  <DialogTitle>{t('Remove member')}</DialogTitle>
+                </DialogHeader>
+                <DialogDescription asChild>
+                  <div className='flex flex-wrap items-center gap-1.5 text-sm text-foreground/80'>
+                    <span>{t('You are about to permanently remove')}</span>
+                    <span className='font-semibold text-foreground'>{person.name}</span>
+                    <span>{t('from the group. Are you sure?')}</span>
+                  </div>
+                </DialogDescription>
+                <DialogFooter>
+                  <button
+                    type='button'
+                    onClick={confirmRemoveMember}
+                    className='rounded-md bg-destructive text-white px-3 py-1.5 text-sm font-medium hover:opacity-90 transition-opacity'
+                  >
+                    {t('Remove')}
+                  </button>
+                  <button
+                    type='button'
+                    onClick={() => setConfirmingRemove(false)}
+                    className='rounded-md border-2 border-foreground/20 px-3 py-1.5 text-sm font-medium text-foreground hover:border-foreground/50 transition-all'
+                  >
+                    {t('Cancel')}
+                  </button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
+          )}
           {(person.tagline || person.bio) && (
             <div className='flex items-center flex-col mb-4'>
               {person.tagline && <div className='text-foreground text-center text-lg font-bold max-w-md'>{person.tagline}</div>}

--- a/apps/web/src/routes/MemberProfile/MemberProfile.test.js
+++ b/apps/web/src/routes/MemberProfile/MemberProfile.test.js
@@ -1,7 +1,8 @@
 import React from 'react'
 import { graphql, HttpResponse } from 'msw'
 import mockGraphqlServer from 'util/testing/mockGraphqlServer'
-import { AllTheProviders, render, screen, waitFor } from 'util/testing/reactTestingLibraryExtended'
+import { AllTheProviders, fireEvent, render, screen, waitFor } from 'util/testing/reactTestingLibraryExtended'
+import { RESP_REMOVE_MEMBERS } from 'store/constants'
 import denormalized from './MemberProfile.test.json'
 import MemberProfile from './MemberProfile.js'
 import orm from 'store/models'
@@ -13,6 +14,29 @@ function testWrapper (providedState) {
   ormSession.Reaction.create(denormalized.data.person.reactions)
   const reduxState = { orm: ormSession.state, ...providedState }
   return AllTheProviders(reduxState)
+}
+
+// Viewing another member's profile (distinct current-user id) within a group, so the
+// "Remove member from group" action's visibility can be exercised by responsibility.
+function testWrapperViewingOtherMember (hasRemoveResponsibility) {
+  const ormSession = orm.mutableSession(orm.getEmptyState())
+  ormSession.Person.create(denormalized.data.person)
+  ormSession.Reaction.create(denormalized.data.person.reactions)
+  ormSession.Group.create({ id: '1', slug: 'test-group', name: 'Test Group' })
+  ormSession.Me.create({
+    id: '999',
+    groupRoles: {
+      items: hasRemoveResponsibility
+        ? [{
+            id: 1,
+            groupId: '1',
+            name: 'Coordinator',
+            responsibilities: { items: [{ id: 1, title: RESP_REMOVE_MEMBERS }] }
+          }]
+        : []
+    }
+  })
+  return AllTheProviders({ orm: ormSession.state })
 }
 
 jest.mock('react-router-dom', () => ({
@@ -168,6 +192,31 @@ describe('MemberProfile', () => {
     render(<MemberProfile />, { wrapper: testWrapper() })
     await waitFor(() => {
       expect(screen.getByText('Oops, there\'s nothing to see here.')).toBeInTheDocument()
+    })
+  })
+
+  describe('remove member action', () => {
+    beforeEach(() => {
+      jest.spyOn(require('react-router-dom'), 'useParams').mockReturnValue({ personId: '46816' })
+      jest.spyOn(require('react-router-dom'), 'useLocation').mockReturnValue({ pathname: '/groups/test-group/members/46816', search: '' })
+    })
+
+    it('shows "Remove member from group" when the current user has the Remove Members responsibility', async () => {
+      render(<MemberProfile />, { wrapper: testWrapperViewingOtherMember(true) })
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: denormalized.data.person.name })).toBeInTheDocument()
+      })
+      fireEvent.click(screen.getAllByTestId('dropdown-toggle')[0])
+      expect(screen.getByText('Remove member from group')).toBeInTheDocument()
+    })
+
+    it('hides "Remove member from group" when the current user lacks the Remove Members responsibility', async () => {
+      render(<MemberProfile />, { wrapper: testWrapperViewingOtherMember(false) })
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: denormalized.data.person.name })).toBeInTheDocument()
+      })
+      fireEvent.click(screen.getAllByTestId('dropdown-toggle')[0])
+      expect(screen.queryByText('Remove member from group')).not.toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
## Summary
- Members with the `Remove Members` responsibility could already remove someone from the group's Members list, but that same action was missing from an individual member's profile page — the three-dot menu there only offered "Edit Profile" (self) and "Block this Member" (others).
- Adds a "Remove member from group" option to that menu, gated behind the same `Remove Members` responsibility check used elsewhere (`RESP_REMOVE_MEMBERS` / `getResponsibilityTitlesForGroup`), reusing the existing `removeMember` GraphQL mutation and a confirmation dialog matching the pattern already used on the Members list (`components/Member/Member.js`).
- Hidden on your own profile and for the Axolotl system account, same as the existing Block action.
- No new translation strings needed — all i18n keys already exist in every locale file.

Closes #332

## Test plan
- [x] Added 2 unit tests to `MemberProfile.test.js` asserting the menu item appears when the current user has the `Remove Members` responsibility in the group, and is hidden when they don't
- [x] All 8 tests in `MemberProfile.test.js` pass
- [x] `standard` lint passes on the changed lines
- [x] Manually verified end-to-end against a local dev environment: logged in as the seeded Coordinator (`test@hylo.com`), opened another member's profile in a group, clicked "Remove member from group," confirmed, and verified in the database that their `group_memberships` row flipped to `active: false` and the group's active member count dropped accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)