### PR TITLE
Auto-fill event meeting link from a Zoom/Meet/Jitsi URL in the description

### DIFF
--- a/apps/web/src/components/PostEditor/PostEditor.js
+++ b/apps/web/src/components/PostEditor/PostEditor.js
@@ -96,7 +96,7 @@ import {
 import { MAX_POST_TOPICS } from 'util/constants'
 import generateTempID from 'util/generateTempId'
 import { setQuerystringParam } from '@hylo/navigation'
-import { sanitizeURL } from 'util/url'
+import { isMeetingUrl, sanitizeURL } from 'util/url'
 import isPlayableVideoUrl from 'util/isPlayableVideoUrl'
 import ActionsBar from './ActionsBar'
 import HyloHTML from 'components/HyloHTML'
@@ -999,7 +999,10 @@ function PostEditorInner ({
 
   const handleAddLinkPreview = useEventCallback((url, force) => {
     debouncedFetchLinkPreview(url, force, currentPost.linkPreview)
-  }, [currentPost.linkPreview, debouncedFetchLinkPreview])
+    if (currentPost.type === 'event' && isMeetingUrl(url)) {
+      setCurrentPost(prev => (prev.meetingLink ? prev : { ...prev, meetingLink: url }))
+    }
+  }, [currentPost.linkPreview, currentPost.type, debouncedFetchLinkPreview, setCurrentPost])
 
   const handleAddTopic = useEventCallback((topic) => {
     setCurrentPost(prev => {

--- a/apps/web/src/util/url.js
+++ b/apps/web/src/util/url.js
@@ -25,3 +25,17 @@ export function normalizeUserLinkHref (raw) {
   }
   return sanitizeURL(url) || url
 }
+
+const MEETING_URL_PATTERNS = [
+  /^https?:\/\/([\w-]+\.)*zoom\.us\//i,
+  /^https?:\/\/meet\.google\.com\//i,
+  /^https?:\/\/meet\.jit\.si\//i
+]
+
+/**
+ * True for a URL from a known video-meeting platform (Zoom, Google Meet, Jitsi).
+ */
+export function isMeetingUrl (url) {
+  if (!url || typeof url !== 'string') return false
+  return MEETING_URL_PATTERNS.some(pattern => pattern.test(url))
+}

--- a/apps/web/src/util/url.test.js
+++ b/apps/web/src/util/url.test.js
@@ -1,0 +1,17 @@
+import { isMeetingUrl } from './url'
+
+describe('isMeetingUrl', () => {
+  it('detects Zoom, Google Meet, and Jitsi links', () => {
+    expect(isMeetingUrl('https://zoom.us/j/1234567890')).toBe(true)
+    expect(isMeetingUrl('https://us02web.zoom.us/j/1234567890')).toBe(true)
+    expect(isMeetingUrl('https://meet.google.com/abc-defg-hij')).toBe(true)
+    expect(isMeetingUrl('https://meet.jit.si/SomeRoomName')).toBe(true)
+  })
+
+  it('rejects non-meeting and empty URLs', () => {
+    expect(isMeetingUrl('https://www.hylo.com/awitp')).toBe(false)
+    expect(isMeetingUrl('https://zoominfo.com/j/1234567890')).toBe(false)
+    expect(isMeetingUrl('')).toBe(false)
+    expect(isMeetingUrl(null)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- When a link from a known video-meeting platform (Zoom, Google Meet, Jitsi) is pasted or typed into an event's description, it's now automatically copied into the "Virtual meeting URL" (Join link) field — unless that field already has a value.
- Detection hooks into `handleAddLinkPreview` in `apps/web/src/components/PostEditor/PostEditor.js`, which already fires live (via the description editor's link-preview mechanism) whenever a URL appears in the description — no new event wiring needed there.
- New `isMeetingUrl(url)` helper added to `apps/web/src/util/url.js`, matching `zoom.us` (including subdomains like `us02web.zoom.us`), `meet.google.com`, and `meet.jit.si`.
- No backend/schema changes needed — the `meetingLink` field, DB column, and GraphQL plumbing already existed end-to-end.

Closes #1511

## Test plan
- [x] New unit tests in `apps/web/src/util/url.test.js` for `isMeetingUrl` — covers Zoom (with and without subdomain), Google Meet, Jitsi, and rejects non-meeting/empty/null input
- [x] Existing `PostEditor.test.js` suite (9 tests) still passes unchanged
- [x] `standard` lint passes on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)