### PR TITLE
Add a Try the demo link to the login page

### DIFF
--- a/apps/web/public/locales/de.json
+++ b/apps/web/public/locales/de.json
@@ -1331,6 +1331,7 @@
   "Not Completed Track": "Track nicht abgeschlossen",
   "Not Going": "Nicht dabei",
   "Not Linked": "Nicht verknüpft",
+  "Try the demo": "Demo ausprobieren",
   "Not a member of Hylo?": "Noch kein Mitglied von Hylo?",
   "Not answered": "Nicht beantwortet",
   "Not enough tokens available": "Nicht genügend Tokens verfügbar",

--- a/apps/web/public/locales/en.json
+++ b/apps/web/public/locales/en.json
@@ -1370,6 +1370,7 @@
   "Not Completed Track": "Not Completed Track",
   "Not Going": "Not Going",
   "Not Linked": "Not Linked",
+  "Try the demo": "Try the demo",
   "Not a member of Hylo?": "Not a member of Hylo?",
   "Not answered": "Not answered",
   "Not enough tokens available": "Not enough tokens available",

--- a/apps/web/public/locales/es.json
+++ b/apps/web/public/locales/es.json
@@ -1362,6 +1362,7 @@
   "Not Completed Track": "Ruta no completada",
   "Not Going": "No voy",
   "Not Linked": "No Vinculado",
+  "Try the demo": "Probar la demo",
   "Not a member of Hylo?": "¿No eres miembro de Hylo?",
   "Not answered": "No contestado",
   "Not enough tokens available": "No hay suficientes tokens disponibles.",

--- a/apps/web/public/locales/fr.json
+++ b/apps/web/public/locales/fr.json
@@ -1330,6 +1330,7 @@
   "Not Completed Track": "Parcours non terminé",
   "Not Going": "Ne participe pas",
   "Not Linked": "Non lié",
+  "Try the demo": "Essayer la démo",
   "Not a member of Hylo?": "Vous n'êtes pas membre de Hylo ?",
   "Not answered": "Sans réponse",
   "Not enough tokens available": "Pas assez de jetons disponibles",

--- a/apps/web/public/locales/hi.json
+++ b/apps/web/public/locales/hi.json
@@ -1332,6 +1332,7 @@
   "Not Completed Track": "ट्रैक पूरा नहीं किया",
   "Not Going": "नहीं जा रहा",
   "Not Linked": "जुड़ा नहीं हुआ",
+  "Try the demo": "डेमो आज़माएँ",
   "Not a member of Hylo?": "Hylo के सदस्य नहीं हैं?",
   "Not answered": "उत्तर नहीं दिया गया",
   "Not enough tokens available": "पर्याप्त टोकन उपलब्ध नहीं हैं",

--- a/apps/web/public/locales/pt.json
+++ b/apps/web/public/locales/pt.json
@@ -1331,6 +1331,7 @@
   "Not Completed Track": "Trilha não concluída",
   "Not Going": "Não vai",
   "Not Linked": "Não vinculado",
+  "Try the demo": "Experimente a demo",
   "Not a member of Hylo?": "Não é membro do Hylo?",
   "Not answered": "Sem resposta",
   "Not enough tokens available": "Tokens insuficientes disponíveis",

--- a/apps/web/src/routes/NonAuthLayoutRouter/Login/Login.js
+++ b/apps/web/src/routes/NonAuthLayoutRouter/Login/Login.js
@@ -154,6 +154,11 @@ export default function Login (props) {
         <div className='flex justify-center px-4 pb-4'>
           <GoogleButton onClick={() => handleLoginWithService('google')} />
         </div>
+        <div className='flex justify-center pb-4'>
+          <a href='/sandbox' className='text-foreground/80 text-sm underline-offset-2 hover:underline'>
+            {t('Try the demo')}
+          </a>
+        </div>
       </div>
     </>
   )

--- a/apps/web/src/routes/NonAuthLayoutRouter/Login/Login.test.js
+++ b/apps/web/src/routes/NonAuthLayoutRouter/Login/Login.test.js
@@ -8,4 +8,5 @@ it('renders correctly', () => {
   )
 
   expect(screen.getByText('Sign in to Hylo')).toBeInTheDocument()
+  expect(screen.getByRole('link', { name: 'Try the demo' })).toHaveAttribute('href', '/sandbox')
 })

--- a/docs/sandbox-mode-proposal.md
+++ b/docs/sandbox-mode-proposal.md
@@ -376,7 +376,7 @@ demo content.
 - [x] Demo banner + reset + signup CTA + locale selector
 - [x] Replace seed placeholders with real copy (EN)
 - [ ] Remaining Tier 3 UX (Zapier, calendar subscribe affordances)
-- [ ] "Try the demo" on web login / marketing
+- [x] "Try the demo" on web login / marketing
 - [ ] Mobile “Try the demo” entry (D15)
 
 ### Phase 4 — payoff


### PR DESCRIPTION
Adds a "Try the demo" link to the web `/login` page pointing at the `/sandbox` demo, matching the "web login" entry tracked in `docs/sandbox-mode-proposal.md`. Addresses #1538.

## Changes
- `apps/web/src/routes/NonAuthLayoutRouter/Login/Login.js` – link below the sign-in card
- Translations for all supported locales (`en`, `es`, `de`, `fr`, `hi`, `pt`)
- Unit test asserting the link renders with `href="/sandbox"`
- `docs/sandbox-mode-proposal.md` – tick the "web login" tracking item

## Test plan
- `yarn test --watchAll=false --testPathPattern=Login` passes (validates the link and its href)
- `yarn build` completes cleanly
- Note: I didn't attach Playwright screenshots because the full e2e harness here requires a local Postgres/backend stack; happy to add them if helpful.

The proposal also mentions a link from the external marketing site, which lives outside this repository, so this PR covers the `/login` part only.